### PR TITLE
bugfix: correct ipv6 string repr. size

### DIFF
--- a/src/iso15118/io/socket_helper.cpp
+++ b/src/iso15118/io/socket_helper.cpp
@@ -7,6 +7,7 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netdb.h>
+#include <netinet/in.h>
 
 #include <iso15118/detail/helper.hpp>
 
@@ -49,8 +50,12 @@ bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, soc
 }
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6& address) {
-    // 4 chars per 2 bytes, 7 colons, 1 '%' and interface name (note, that IFNAMESIZ already include null termination)
-    static constexpr auto MAX_NUMERIC_NAME_LENGTH = 8 * 4 + 7 * 1 + 1 + IFNAMSIZ;
+    // account for ipv6 address string length plus possible scope/zone
+    // identifier which seems to be an interface name, as both constants
+    // (INET6_ADDRSTRLEN and IFNAMSIZ) include the terminating NULL, we
+    // have one extra character that can account for the separating '%'
+    // between the ipv6 address and the scope/zone identifier
+    static constexpr auto MAX_NUMERIC_NAME_LENGTH = INET6_ADDRSTRLEN + IFNAMSIZ;
     auto name = std::make_unique<char[]>(MAX_NUMERIC_NAME_LENGTH);
 
     // FIXME (aw): what about alignment issues here between casting from sockaddr_in6 to sockaddr?


### PR DESCRIPTION
- use predefined value for ipv6 address string length and account for possible zone/scope identifier
- see also https://stackoverflow.com/questions/166132/maximum-length-of-the-textual-representation-of-an-ipv6-address

## Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

