### PR TITLE
Fix gcc 14 compile error

### DIFF
--- a/src/iso15118/d20/state/service_selection.cpp
+++ b/src/iso15118/d20/state/service_selection.cpp
@@ -3,6 +3,8 @@
 #include <iso15118/d20/state/dc_charge_parameter_discovery.hpp>
 #include <iso15118/d20/state/service_selection.hpp>
 
+#include <algorithm>
+
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/service_detail.hpp>
 #include <iso15118/detail/d20/state/service_selection.hpp>


### PR DESCRIPTION
## Describe your changes
Adding missing `include <algorithm>`.

## Issue ticket number and link
Building with gcc 14 did not work because of `std::find` was not found. Error message: `error: ‘find’ is not a member of ‘std’; did you mean ‘bind’?`. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

