### PR TITLE
Changed ISO15118_BUILD_TESTS to BUILD_TESTING

### DIFF
--- a/.ci/build-kit/build_and_test.sh
+++ b/.ci/build-kit/build_and_test.sh
@@ -6,7 +6,7 @@ cmake \
     -B build \
     -S "$EXT_MOUNT/source" \
     -G Ninja \
-    -DISO15118_BUILD_TESTS=ON \
+    -DBUILD_TESTING=ON  \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 ninja -j$(nproc) -C build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(iso15118
-    VERSION 0.1
+    VERSION 0.1.1
     DESCRIPTION "iso15118 library suite"
 	LANGUAGES CXX C
 )
@@ -11,6 +11,8 @@ find_package(everest-cmake 0.1 REQUIRED
 )
 
 # options
+option(${PROJECT_NAME}_BUILD_TESTING "Build unit tests, used if included as dependency" OFF)
+option(BUILD_TESTING "Build unit tests, used if standalone project" OFF)
 option(OPT_AUTODOWNLOAD_ISO20_SCHEMAS "\
 Automatically download ISO15118-20 schemas.  Note: by setting this option to \
 true and hence downloading the schema files, YOU accept the ISO Customer \
@@ -27,6 +29,10 @@ if (USING_OPENSSL)
     find_package(OpenSSL 3 REQUIRED)
 endif()
 
+if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TESTING) AND BUILD_TESTING)
+    set(ISO15118_BUILD_TESTING ON)
+endif()
+
 # dependencies
 if (NOT DISABLE_EDM)
     evc_setup_edm()
@@ -41,7 +47,7 @@ add_subdirectory(3rd_party)
 add_subdirectory(input)
 add_subdirectory(src)
 
-if (ISO15118_BUILD_TESTS)
+if (ISO15118_BUILD_TESTING)
     include(CTest)
     list(APPEND CMAKE_MODULE_PATH ${CPM_PACKAGE_catch2_SOURCE_DIR}/extras)
     add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To build this library you need [everest-cmake](https://github.com/EVerest/everes
 ## Getting started
 
 ```
-# Run cmake (ISO15118_BUILD_TESTS to enable/disable unit tests)
-cmake -S . -B build -G Ninja -DISO15118_BUILD_TESTS=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+# Run cmake (BUILD_TESTING to enable/disable unit tests)
+cmake -S . -B build -G Ninja -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 # Build
 ninja -C build

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,7 +6,7 @@ libfsm:
 catch2:
   git: https://github.com/catchorg/Catch2.git
   git_tag: v3.4.0
-  cmake_condition: "ISO15118_BUILD_TESTS"
+  cmake_condition: "ISO15118_BUILD_TESTING"
 libcbv2g:
   git: https://github.com/EVerest/libcbv2g.git
   git_tag: v0.2.0


### PR DESCRIPTION
## Describe your changes
Other EVerest libraries have used the BUILD_TESTING definition. Now libiso15118 also uses it.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

