### PR TITLE
Adding missing ISO15118_INSTALL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ true and hence downloading the schema files, YOU accept the ISO Customer \
 Licence Agreement (“Licence Agreement”), clauses 1. ISO’s Copyright, \
 7. Termination, 8. Limitations, and 9. Governing Law." OFF)
 
+option(ISO15118_INSTALL "Enable install target" ${EVC_MAIN_PROJECT})
+
 option(ISO15118_LINK_CUSTOM_MBEDTLS "\
 Link against a pinned mbedtls library\
 " ON)


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
For Yocto builds `ISO15118_INSTALL` option was missing

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

