### PR TITLE
Refactor: Multiple Sessions now possible

### DIFF
--- a/include/iso15118/d20/context.hpp
+++ b/include/iso15118/d20/context.hpp
@@ -55,8 +55,8 @@ std::unique_ptr<MessageExchange> create_message_exchange(uint8_t* buf, const siz
 class Context {
 public:
     // FIXME (aw): bundle arguments
-    Context(MessageExchange&, const std::optional<ControlEvent>&, session::feedback::Callbacks, bool&,
-            session::SessionLogger&, const d20::SessionConfig&);
+    Context(MessageExchange&, const std::optional<ControlEvent>&, session::feedback::Callbacks, session::SessionLogger&,
+            const d20::SessionConfig&);
 
     std::unique_ptr<message_20::Variant> pull_request();
     message_20::Type peek_request_type() const;
@@ -89,7 +89,7 @@ public:
 
     const SessionConfig& config;
 
-    bool& session_stopped;
+    bool session_stopped{false};
 
 private:
     const std::optional<ControlEvent>& current_control_event;

--- a/include/iso15118/session/iso.hpp
+++ b/include/iso15118/session/iso.hpp
@@ -36,6 +36,10 @@ public:
     TimePoint const& poll();
     void push_control_event(const d20::ControlEvent&);
 
+    bool is_finished() const {
+        return ctx.session_stopped;
+    }
+
 private:
     std::unique_ptr<io::IConnection> connection;
     session::SessionLogger log;
@@ -59,8 +63,6 @@ private:
     d20::Fsm fsm;
 
     TimePoint next_session_event;
-
-    bool session_stopped{false};
 
     void handle_connection_event(io::ConnectionEvent event);
 };

--- a/include/iso15118/tbd_controller.hpp
+++ b/include/iso15118/tbd_controller.hpp
@@ -41,7 +41,7 @@ private:
 
     d20::SessionConfig session_config;
 
-    std::list<Session> sessions;
+    std::unique_ptr<Session> session;
 
     // callbacks for sdp server
     void handle_sdp_server_input();

--- a/src/iso15118/d20/context.cpp
+++ b/src/iso15118/d20/context.cpp
@@ -52,13 +52,12 @@ message_20::Type MessageExchange::peek_request_type() const {
 }
 
 Context::Context(MessageExchange& message_exchange_, const std::optional<ControlEvent>& current_control_event_,
-                 session::feedback::Callbacks feedback_callbacks, bool& stopping_, session::SessionLogger& logger,
+                 session::feedback::Callbacks feedback_callbacks, session::SessionLogger& logger,
                  const d20::SessionConfig& config_) :
     current_control_event{current_control_event_},
     feedback(std::move(feedback_callbacks)),
     log(logger),
     message_exchange(message_exchange_),
-    session_stopped(stopping_),
     config(config_) {
 }
 

--- a/src/iso15118/io/connection_plain.cpp
+++ b/src/iso15118/io/connection_plain.cpp
@@ -38,6 +38,17 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     // before bind, set the port
     address.sin6_port = htobe16(end_point.port);
 
+    int optval_tmp{1};
+    const auto set_reuseaddr = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));
+    if (set_reuseaddr == -1) {
+        log_and_throw("setsockopt(SO_REUSEADDR) failed");
+    }
+
+    const auto set_reuseport = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp));
+    if (set_reuseport == -1) {
+        log_and_throw("setsockopt(SO_REUSEPORT) failed");
+    }
+
     const auto bind_result = bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address));
     if (bind_result == -1) {
         const auto error = "Failed to bind ipv6 socket to interface " + interface_name;

--- a/src/iso15118/session/iso.cpp
+++ b/src/iso15118/session/iso.cpp
@@ -121,9 +121,7 @@ static size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::Payloa
 
 Session::Session(std::unique_ptr<io::IConnection> connection_, const d20::SessionConfig& config,
                  const session::feedback::Callbacks& callbacks) :
-    connection(std::move(connection_)),
-    log(this),
-    ctx(message_exchange, active_control_event, callbacks, session_stopped, log, config) {
+    connection(std::move(connection_)), log(this), ctx(message_exchange, active_control_event, callbacks, log, config) {
 
     next_session_event = offset_time_point_by_ms(get_current_time_point(), SESSION_IDLE_TIMEOUT_MS);
     connection->set_event_callback([this](io::ConnectionEvent event) { this->handle_connection_event(event); });
@@ -187,9 +185,8 @@ TimePoint const& Session::poll() {
 
         ctx.feedback.v2g_message(response_type);
 
-        if (session_stopped) {
+        if (ctx.session_stopped) {
             connection->close();
-            session_stopped = false; // reset
             ctx.feedback.signal(session::feedback::Signal::DLINK_TERMINATE);
         }
     }

--- a/test/iso15118/fsm/helper.hpp
+++ b/test/iso15118/fsm/helper.hpp
@@ -18,7 +18,7 @@ using namespace iso15118;
 class FsmStateHelper {
 public:
     FsmStateHelper(const d20::SessionConfig& config) :
-        log(this), ctx(msg_exch, active_control_event, callbacks, session_stopped, log, config){};
+        log(this), ctx(msg_exch, active_control_event, callbacks, log, config){};
 
     d20::Context& get_context();
 


### PR DESCRIPTION
## Describe your changes
Remove sessions list and added only one session to tbd_controller. If the session is finished, the session ptr is released.
Correct openssl tls server shutdown.

## Issue ticket number and link
Until now, it was not possible to run several sessions in a row. The problem was adding each new session to a list. The old actual closed sessions remained in the list and were never properly released.
Now every session is freed by a reset after the TCP/TLS close. As soon as a new SDP request message is received, a new session unique ptr is created.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

