### PR TITLE
Feat: Adding initial iso mux support

### DIFF
--- a/include/iso15118/tbd_controller.hpp
+++ b/include/iso15118/tbd_controller.hpp
@@ -20,6 +20,7 @@ struct TbdConfig {
     config::SSLConfig ssl{config::CertificateBackend::EVEREST_LAYOUT, ""};
     std::string interface_name;
     config::TlsNegotiationStrategy tls_negotiation_strategy{config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER};
+    bool enable_sdp_server{true};
 };
 
 class TbdController {
@@ -36,7 +37,7 @@ public:
 
 private:
     io::PollManager poll_manager;
-    io::SdpServer sdp_server;
+    std::unique_ptr<io::SdpServer> sdp_server;
 
     d20::SessionConfig session_config;
 

--- a/src/iso15118/io/socket_helper.cpp
+++ b/src/iso15118/io/socket_helper.cpp
@@ -39,7 +39,9 @@ bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, soc
 
         // NOTE (aw): because we did the check for AF_INET6, we can assume that ifa_addr is indeed an sockaddr_in6
         const auto current_addr = reinterpret_cast<const sockaddr_in6*>(current_if->ifa_addr);
-        if (not IN6_IS_ADDR_LINKLOCAL(&(current_addr->sin6_addr))) {
+
+        // NOTE (sl): If using loopback device, accept any address. Loopback usually does not have a link local address
+        if (interface_name.compare("lo") != 0 and not IN6_IS_ADDR_LINKLOCAL(&(current_addr->sin6_addr))) {
             continue;
         }
 


### PR DESCRIPTION
## Describe your changes
For https://github.com/EVerest/everest-core/pull/776 we need some changes. SDP Server should be configurable and TCP server should listen on ::1. Libiso15118 should also work if the lo interface does not have a link local address available (Only with iso mux module).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

