### PR TITLE
Refactoring iso20 data types

### DIFF
--- a/include/iso15118/d20/config.hpp
+++ b/include/iso15118/d20/config.hpp
@@ -7,19 +7,19 @@
 #include <vector>
 
 #include <iso15118/d20/limits.hpp>
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 
 namespace iso15118::d20 {
 
 struct ControlMobilityNeedsModes {
-    message_20::ControlMode control_mode;
-    message_20::MobilityNeedsMode mobility_mode;
+    message_20::datatypes::ControlMode control_mode;
+    message_20::datatypes::MobilityNeedsMode mobility_mode;
 };
 
 struct EvseSetupConfig {
     std::string evse_id;
-    std::vector<message_20::ServiceCategory> supported_energy_services;
-    std::vector<message_20::Authorization> authorization_services;
+    std::vector<message_20::datatypes::ServiceCategory> supported_energy_services;
+    std::vector<message_20::datatypes::Authorization> authorization_services;
     bool enable_certificate_install_service;
     d20::DcTransferLimits dc_limits;
     std::vector<ControlMobilityNeedsModes> control_mobility_modes;
@@ -31,16 +31,16 @@ struct SessionConfig {
     std::string evse_id;
 
     bool cert_install_service;
-    std::vector<message_20::Authorization> authorization_services;
+    std::vector<message_20::datatypes::Authorization> authorization_services;
 
-    std::vector<message_20::ServiceCategory> supported_energy_transfer_services;
-    std::vector<message_20::ServiceCategory> supported_vas_services;
+    std::vector<message_20::datatypes::ServiceCategory> supported_energy_transfer_services;
+    std::vector<message_20::datatypes::ServiceCategory> supported_vas_services;
 
-    std::vector<message_20::DcParameterList> dc_parameter_list;
-    std::vector<message_20::DcBptParameterList> dc_bpt_parameter_list;
+    std::vector<message_20::datatypes::DcParameterList> dc_parameter_list;
+    std::vector<message_20::datatypes::DcBptParameterList> dc_bpt_parameter_list;
 
-    std::vector<message_20::InternetParameterList> internet_parameter_list;
-    std::vector<message_20::ParkingParameterList> parking_parameter_list;
+    std::vector<message_20::datatypes::InternetParameterList> internet_parameter_list;
+    std::vector<message_20::datatypes::ParkingParameterList> parking_parameter_list;
 
     DcTransferLimits dc_limits;
 

--- a/include/iso15118/d20/limits.hpp
+++ b/include/iso15118/d20/limits.hpp
@@ -4,7 +4,7 @@
 
 #include <optional>
 
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 
 namespace iso15118::d20 {
 
@@ -14,15 +14,15 @@ template <typename T> struct Limit {
 };
 
 struct Limits {
-    Limit<message_20::RationalNumber> power;
-    Limit<message_20::RationalNumber> current;
+    Limit<message_20::datatypes::RationalNumber> power;
+    Limit<message_20::datatypes::RationalNumber> current;
 };
 
 struct DcTransferLimits {
     Limits charge_limits;
     std::optional<Limits> discharge_limits;
-    Limit<message_20::RationalNumber> voltage;
-    std::optional<message_20::RationalNumber> power_ramp_limit;
+    Limit<message_20::datatypes::RationalNumber> voltage;
+    std::optional<message_20::datatypes::RationalNumber> power_ramp_limit;
 };
 
 } // namespace iso15118::d20

--- a/include/iso15118/d20/session.hpp
+++ b/include/iso15118/d20/session.hpp
@@ -8,69 +8,73 @@
 #include <variant>
 #include <vector>
 
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 
 namespace iso15118::d20 {
 
 struct OfferedServices {
 
-    std::vector<message_20::Authorization> auth_services;
-    std::vector<message_20::ServiceCategory> energy_services;
-    std::vector<message_20::ServiceCategory> vas_services;
+    std::vector<message_20::datatypes::Authorization> auth_services;
+    std::vector<message_20::datatypes::ServiceCategory> energy_services;
+    std::vector<message_20::datatypes::ServiceCategory> vas_services;
 
-    std::map<uint8_t, message_20::DcParameterList> dc_parameter_list;
-    std::map<uint8_t, message_20::DcBptParameterList> dc_bpt_parameter_list;
-    std::map<uint8_t, message_20::InternetParameterList> internet_parameter_list;
-    std::map<uint8_t, message_20::ParkingParameterList> parking_parameter_list;
+    std::map<uint8_t, message_20::datatypes::DcParameterList> dc_parameter_list;
+    std::map<uint8_t, message_20::datatypes::DcBptParameterList> dc_bpt_parameter_list;
+    std::map<uint8_t, message_20::datatypes::InternetParameterList> internet_parameter_list;
+    std::map<uint8_t, message_20::datatypes::ParkingParameterList> parking_parameter_list;
 };
 
 struct SelectedServiceParameters {
 
-    message_20::ServiceCategory selected_energy_service;
+    message_20::datatypes::ServiceCategory selected_energy_service;
 
-    std::variant<message_20::AcConnector, message_20::DcConnector> selected_connector;
-    message_20::ControlMode selected_control_mode;
-    message_20::MobilityNeedsMode selected_mobility_needs_mode;
-    message_20::Pricing selected_pricing;
+    std::variant<message_20::datatypes::AcConnector, message_20::datatypes::DcConnector> selected_connector;
+    message_20::datatypes::ControlMode selected_control_mode;
+    message_20::datatypes::MobilityNeedsMode selected_mobility_needs_mode;
+    message_20::datatypes::Pricing selected_pricing;
 
-    message_20::BptChannel selected_bpt_channel;
-    message_20::GeneratorMode selected_generator_mode;
+    message_20::datatypes::BptChannel selected_bpt_channel;
+    message_20::datatypes::GeneratorMode selected_generator_mode;
 
     SelectedServiceParameters(){}; // TODO(sl): What to do here?
     // Constructor for DC
-    SelectedServiceParameters(message_20::ServiceCategory energy_service_, message_20::DcConnector dc_connector_,
-                              message_20::ControlMode control_mode_, message_20::MobilityNeedsMode mobility_,
-                              message_20::Pricing pricing_) :
+    SelectedServiceParameters(message_20::datatypes::ServiceCategory energy_service_,
+                              message_20::datatypes::DcConnector dc_connector_,
+                              message_20::datatypes::ControlMode control_mode_,
+                              message_20::datatypes::MobilityNeedsMode mobility_,
+                              message_20::datatypes::Pricing pricing_) :
         selected_energy_service(energy_service_),
         selected_control_mode(control_mode_),
         selected_mobility_needs_mode(mobility_),
         selected_pricing(pricing_) {
-        selected_connector.emplace<message_20::DcConnector>(dc_connector_);
+        selected_connector.emplace<message_20::datatypes::DcConnector>(dc_connector_);
     };
 
     // Constructor for DC_BPT
-    SelectedServiceParameters(message_20::ServiceCategory energy_service_, message_20::DcConnector dc_connector_,
-                              message_20::ControlMode control_mode_, message_20::MobilityNeedsMode mobility_,
-                              message_20::Pricing pricing_, message_20::BptChannel channel_,
-                              message_20::GeneratorMode generator_) :
+    SelectedServiceParameters(message_20::datatypes::ServiceCategory energy_service_,
+                              message_20::datatypes::DcConnector dc_connector_,
+                              message_20::datatypes::ControlMode control_mode_,
+                              message_20::datatypes::MobilityNeedsMode mobility_,
+                              message_20::datatypes::Pricing pricing_, message_20::datatypes::BptChannel channel_,
+                              message_20::datatypes::GeneratorMode generator_) :
         selected_energy_service(energy_service_),
         selected_control_mode(control_mode_),
         selected_mobility_needs_mode(mobility_),
         selected_pricing(pricing_),
         selected_bpt_channel(channel_),
         selected_generator_mode(generator_) {
-        selected_connector.emplace<message_20::DcConnector>(dc_connector_);
+        selected_connector.emplace<message_20::datatypes::DcConnector>(dc_connector_);
     };
 };
 
 struct SelectedVasParameter {
-    std::vector<message_20::ServiceCategory> vas_services;
+    std::vector<message_20::datatypes::ServiceCategory> vas_services;
 
-    message_20::Protocol internet_protocol;
-    message_20::Port internet_port;
+    message_20::datatypes::Protocol internet_protocol;
+    message_20::datatypes::Port internet_port;
 
-    message_20::IntendedService parking_intended_service;
-    message_20::ParkingStatus parking_status;
+    message_20::datatypes::IntendedService parking_intended_service;
+    message_20::datatypes::ParkingStatus parking_status;
 };
 
 class Session {
@@ -87,9 +91,9 @@ public:
         return id;
     }
 
-    bool find_parameter_set_id(const message_20::ServiceCategory service, int16_t id);
+    bool find_parameter_set_id(const message_20::datatypes::ServiceCategory service, int16_t id);
 
-    void selected_service_parameters(const message_20::ServiceCategory service, const uint16_t id);
+    void selected_service_parameters(const message_20::datatypes::ServiceCategory service, const uint16_t id);
 
     auto get_selected_services() const& {
         return selected_services;

--- a/include/iso15118/d20/state/authorization.hpp
+++ b/include/iso15118/d20/state/authorization.hpp
@@ -15,7 +15,7 @@ struct Authorization : public FsmSimpleState {
     HandleEventReturnType handle_event(AllocatorType&, FsmEvent) final;
 
 private:
-    message_20::AuthStatus authorization_status{message_20::AuthStatus::Pending};
+    message_20::datatypes::AuthStatus authorization_status{message_20::datatypes::AuthStatus::Pending};
 };
 
 } // namespace iso15118::d20::state

--- a/include/iso15118/detail/cb_exi.hpp
+++ b/include/iso15118/detail/cb_exi.hpp
@@ -23,6 +23,12 @@
     std::copy(in.begin(), in.end(), out.bytes);                                                                        \
     out.bytesLen = in.size()
 
+#define CB2CPP_BYTES(in, out)                                                                                          \
+    if (in.bytesLen > out.size()) {                                                                                    \
+        throw std::runtime_error("Byte array too long");                                                               \
+    }                                                                                                                  \
+    std::copy(std::begin(in.bytes), std::end(in.bytes), out.begin());
+
 #define CB_SET_USED(property) (property##_isUsed = 1)
 #define CB2CPP_ASSIGN_IF_USED(in, out)                                                                                 \
     if (in##_isUsed) {                                                                                                 \

--- a/include/iso15118/detail/d20/context_helper.hpp
+++ b/include/iso15118/detail/d20/context_helper.hpp
@@ -4,7 +4,7 @@
 
 #include <iso15118/d20/context.hpp>
 #include <iso15118/d20/session.hpp>
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 
 namespace iso15118::d20 {
 

--- a/include/iso15118/detail/d20/state/authorization.hpp
+++ b/include/iso15118/detail/d20/state/authorization.hpp
@@ -9,6 +9,6 @@ namespace iso15118::d20::state {
 
 message_20::AuthorizationResponse handle_request(const message_20::AuthorizationRequest& req,
                                                  const d20::Session& session,
-                                                 const message_20::AuthStatus& authorization_status);
+                                                 const message_20::datatypes::AuthStatus& authorization_status);
 
 } // namespace iso15118::d20::state

--- a/include/iso15118/detail/d20/state/authorization_setup.hpp
+++ b/include/iso15118/detail/d20/state/authorization_setup.hpp
@@ -10,6 +10,6 @@ namespace iso15118::d20::state {
 
 message_20::AuthorizationSetupResponse
 handle_request(const message_20::AuthorizationSetupRequest& req, d20::Session& session, bool cert_install_service,
-               const std::vector<message_20::Authorization>& authorization_services);
+               const std::vector<message_20::datatypes::Authorization>& authorization_services);
 
 } // namespace iso15118::d20::state

--- a/include/iso15118/detail/d20/state/schedule_exchange.hpp
+++ b/include/iso15118/detail/d20/state/schedule_exchange.hpp
@@ -15,7 +15,7 @@ namespace iso15118::d20::state {
 
 message_20::ScheduleExchangeResponse handle_request(const message_20::ScheduleExchangeRequest& req,
                                                     const d20::Session& session,
-                                                    const message_20::RationalNumber& max_power,
+                                                    const message_20::datatypes::RationalNumber& max_power,
                                                     const UpdateDynamicModeParameters& dynamic_parameters);
 
 } // namespace iso15118::d20::state

--- a/include/iso15118/detail/d20/state/service_discovery.hpp
+++ b/include/iso15118/detail/d20/state/service_discovery.hpp
@@ -6,14 +6,14 @@
 
 #include <iso15118/d20/config.hpp>
 #include <iso15118/d20/session.hpp>
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 #include <iso15118/message/service_discovery.hpp>
 
 namespace iso15118::d20::state {
 
-message_20::ServiceDiscoveryResponse handle_request(const message_20::ServiceDiscoveryRequest& req,
-                                                    d20::Session& session,
-                                                    const std::vector<message_20::ServiceCategory>& energy_services,
-                                                    const std::vector<message_20::ServiceCategory>& vas_services);
+message_20::ServiceDiscoveryResponse
+handle_request(const message_20::ServiceDiscoveryRequest& req, d20::Session& session,
+               const std::vector<message_20::datatypes::ServiceCategory>& energy_services,
+               const std::vector<message_20::datatypes::ServiceCategory>& vas_services);
 
 } // namespace iso15118::d20::state

--- a/include/iso15118/message/ac_charge_loop.hpp
+++ b/include/iso15118/message/ac_charge_loop.hpp
@@ -5,116 +5,118 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+struct Scheduled_AC_CLReqControlMode : Scheduled_CLReqControlMode {
+    std::optional<RationalNumber> max_charge_power;
+    std::optional<RationalNumber> max_charge_power_L2;
+    std::optional<RationalNumber> max_charge_power_L3;
+    std::optional<RationalNumber> min_charge_power;
+    std::optional<RationalNumber> min_charge_power_L2;
+    std::optional<RationalNumber> min_charge_power_L3;
+    RationalNumber present_active_power;
+    std::optional<RationalNumber> present_active_power_L2;
+    std::optional<RationalNumber> present_active_power_L3;
+    std::optional<RationalNumber> present_reactive_power;
+    std::optional<RationalNumber> present_reactive_power_L2;
+    std::optional<RationalNumber> present_reactive_power_L3;
+};
+
+struct BPT_Scheduled_AC_CLReqControlMode : Scheduled_AC_CLReqControlMode {
+    std::optional<RationalNumber> max_discharge_power;
+    std::optional<RationalNumber> max_discharge_power_L2;
+    std::optional<RationalNumber> max_discharge_power_L3;
+    std::optional<RationalNumber> min_discharge_power;
+    std::optional<RationalNumber> min_discharge_power_L2;
+    std::optional<RationalNumber> min_discharge_power_L3;
+};
+
+struct Dynamic_AC_CLReqControlMode : Dynamic_CLReqControlMode {
+    RationalNumber max_charge_power;
+    std::optional<RationalNumber> max_charge_power_L2;
+    std::optional<RationalNumber> max_charge_power_L3;
+    RationalNumber min_charge_power;
+    std::optional<RationalNumber> min_charge_power_L2;
+    std::optional<RationalNumber> min_charge_power_L3;
+    RationalNumber present_active_power;
+    std::optional<RationalNumber> present_active_power_L2;
+    std::optional<RationalNumber> present_active_power_L3;
+    RationalNumber present_reactive_power;
+    std::optional<RationalNumber> present_reactive_power_L2;
+    std::optional<RationalNumber> present_reactive_power_L3;
+};
+
+struct BPT_Dynamic_AC_CLReqControlMode : Dynamic_AC_CLReqControlMode {
+    RationalNumber max_discharge_power;
+    std::optional<RationalNumber> max_discharge_power_L2;
+    std::optional<RationalNumber> max_discharge_power_L3;
+    RationalNumber min_discharge_power;
+    std::optional<RationalNumber> min_discharge_power_L2;
+    std::optional<RationalNumber> min_discharge_power_L3;
+    std::optional<RationalNumber> max_v2x_energy_request;
+    std::optional<RationalNumber> min_v2x_energy_request;
+};
+
+struct Scheduled_AC_CLResControlMode : Scheduled_CLResControlMode {
+    std::optional<RationalNumber> target_active_power;
+    std::optional<RationalNumber> target_active_power_L2;
+    std::optional<RationalNumber> target_active_power_L3;
+    std::optional<RationalNumber> target_reactive_power;
+    std::optional<RationalNumber> target_reactive_power_L2;
+    std::optional<RationalNumber> target_reactive_power_L3;
+    std::optional<RationalNumber> present_active_power;
+    std::optional<RationalNumber> present_active_power_L2;
+    std::optional<RationalNumber> present_active_power_L3;
+};
+
+struct BPT_Scheduled_AC_CLResControlMode : Scheduled_AC_CLResControlMode {};
+
+struct Dynamic_AC_CLResControlMode : Dynamic_CLResControlMode {
+    RationalNumber target_active_power;
+    std::optional<RationalNumber> target_active_power_L2;
+    std::optional<RationalNumber> target_active_power_L3;
+    std::optional<RationalNumber> target_reactive_power;
+    std::optional<RationalNumber> target_reactive_power_L2;
+    std::optional<RationalNumber> target_reactive_power_L3;
+    std::optional<RationalNumber> present_active_power;
+    std::optional<RationalNumber> present_active_power_L2;
+    std::optional<RationalNumber> present_active_power_L3;
+};
+
+struct BPT_Dynamic_AC_CLResControlMode : Dynamic_AC_CLResControlMode {};
+
+} // namespace datatypes
+
 struct AC_ChargeLoopRequest {
-
-    struct Scheduled_AC_CLReqControlMode : Scheduled_CLReqControlMode {
-        std::optional<RationalNumber> max_charge_power;
-        std::optional<RationalNumber> max_charge_power_L2;
-        std::optional<RationalNumber> max_charge_power_L3;
-        std::optional<RationalNumber> min_charge_power;
-        std::optional<RationalNumber> min_charge_power_L2;
-        std::optional<RationalNumber> min_charge_power_L3;
-        RationalNumber present_active_power;
-        std::optional<RationalNumber> present_active_power_L2;
-        std::optional<RationalNumber> present_active_power_L3;
-        std::optional<RationalNumber> present_reactive_power;
-        std::optional<RationalNumber> present_reactive_power_L2;
-        std::optional<RationalNumber> present_reactive_power_L3;
-    };
-
-    struct BPT_Scheduled_AC_CLReqControlMode : Scheduled_AC_CLReqControlMode {
-        std::optional<RationalNumber> max_discharge_power;
-        std::optional<RationalNumber> max_discharge_power_L2;
-        std::optional<RationalNumber> max_discharge_power_L3;
-        std::optional<RationalNumber> min_discharge_power;
-        std::optional<RationalNumber> min_discharge_power_L2;
-        std::optional<RationalNumber> min_discharge_power_L3;
-    };
-
-    struct Dynamic_AC_CLReqControlMode : Dynamic_CLReqControlMode {
-        RationalNumber max_charge_power;
-        std::optional<RationalNumber> max_charge_power_L2;
-        std::optional<RationalNumber> max_charge_power_L3;
-        RationalNumber min_charge_power;
-        std::optional<RationalNumber> min_charge_power_L2;
-        std::optional<RationalNumber> min_charge_power_L3;
-        RationalNumber present_active_power;
-        std::optional<RationalNumber> present_active_power_L2;
-        std::optional<RationalNumber> present_active_power_L3;
-        RationalNumber present_reactive_power;
-        std::optional<RationalNumber> present_reactive_power_L2;
-        std::optional<RationalNumber> present_reactive_power_L3;
-    };
-
-    struct BPT_Dynamic_AC_CLReqControlMode : Dynamic_AC_CLReqControlMode {
-        RationalNumber max_discharge_power;
-        std::optional<RationalNumber> max_discharge_power_L2;
-        std::optional<RationalNumber> max_discharge_power_L3;
-        RationalNumber min_discharge_power;
-        std::optional<RationalNumber> min_discharge_power_L2;
-        std::optional<RationalNumber> min_discharge_power_L3;
-        std::optional<RationalNumber> max_v2x_energy_request;
-        std::optional<RationalNumber> min_v2x_energy_request;
-    };
-
     Header header;
 
     // the following 2 are inherited from ChargeLoopReq
-    std::optional<DisplayParameters> display_parameters;
+    std::optional<datatypes::DisplayParameters> display_parameters;
     bool meter_info_requested;
 
-    std::variant<Scheduled_AC_CLReqControlMode, BPT_Scheduled_AC_CLReqControlMode, Dynamic_AC_CLReqControlMode,
-                 BPT_Dynamic_AC_CLReqControlMode>
+    std::variant<datatypes::Scheduled_AC_CLReqControlMode, datatypes::BPT_Scheduled_AC_CLReqControlMode,
+                 datatypes::Dynamic_AC_CLReqControlMode, datatypes::BPT_Dynamic_AC_CLReqControlMode>
         control_mode;
 };
 
 struct AC_ChargeLoopResponse {
-
-    struct Scheduled_AC_CLResControlMode : Scheduled_CLResControlMode {
-        std::optional<RationalNumber> target_active_power;
-        std::optional<RationalNumber> target_active_power_L2;
-        std::optional<RationalNumber> target_active_power_L3;
-        std::optional<RationalNumber> target_reactive_power;
-        std::optional<RationalNumber> target_reactive_power_L2;
-        std::optional<RationalNumber> target_reactive_power_L3;
-        std::optional<RationalNumber> present_active_power;
-        std::optional<RationalNumber> present_active_power_L2;
-        std::optional<RationalNumber> present_active_power_L3;
-    };
-
-    struct BPT_Scheduled_AC_CLResControlMode : Scheduled_AC_CLResControlMode {};
-
-    struct Dynamic_AC_CLResControlMode : Dynamic_CLResControlMode {
-        RationalNumber target_active_power;
-        std::optional<RationalNumber> target_active_power_L2;
-        std::optional<RationalNumber> target_active_power_L3;
-        std::optional<RationalNumber> target_reactive_power;
-        std::optional<RationalNumber> target_reactive_power_L2;
-        std::optional<RationalNumber> target_reactive_power_L3;
-        std::optional<RationalNumber> present_active_power;
-        std::optional<RationalNumber> present_active_power_L2;
-        std::optional<RationalNumber> present_active_power_L3;
-    };
-
-    struct BPT_Dynamic_AC_CLResControlMode : Dynamic_AC_CLResControlMode {};
-
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
     // the following 3 are inherited from ChargeLoopRes
-    std::optional<EvseStatus> status;
-    std::optional<MeterInfo> meter_info;
-    std::optional<Receipt> receipt;
+    std::optional<datatypes::EvseStatus> status;
+    std::optional<datatypes::MeterInfo> meter_info;
+    std::optional<datatypes::Receipt> receipt;
 
-    std::optional<RationalNumber> target_frequency;
+    std::optional<datatypes::RationalNumber> target_frequency;
 
-    std::variant<Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlMode, Dynamic_AC_CLResControlMode,
-                 BPT_Dynamic_AC_CLResControlMode>
-        control_mode = Scheduled_AC_CLResControlMode();
+    std::variant<datatypes::Scheduled_AC_CLResControlMode, datatypes::BPT_Scheduled_AC_CLResControlMode,
+                 datatypes::Dynamic_AC_CLResControlMode, datatypes::BPT_Dynamic_AC_CLResControlMode>
+        control_mode = datatypes::Scheduled_AC_CLResControlMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/ac_charge_parameter_discovery.hpp
+++ b/include/iso15118/message/ac_charge_parameter_discovery.hpp
@@ -5,65 +5,68 @@
 #include <optional>
 #include <variant>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+struct AC_CPDReqEnergyTransferMode {
+    RationalNumber max_charge_power;
+    std::optional<RationalNumber> max_charge_power_L2;
+    std::optional<RationalNumber> max_charge_power_L3;
+    RationalNumber min_charge_power;
+    std::optional<RationalNumber> min_charge_power_L2;
+    std::optional<RationalNumber> min_charge_power_L3;
+};
+
+struct BPT_AC_CPDReqEnergyTransferMode : AC_CPDReqEnergyTransferMode {
+    RationalNumber max_discharge_power;
+    std::optional<RationalNumber> max_discharge_power_L2;
+    std::optional<RationalNumber> max_discharge_power_L3;
+    RationalNumber min_discharge_power;
+    std::optional<RationalNumber> min_discharge_power_L2;
+    std::optional<RationalNumber> min_discharge_power_L3;
+};
+
+struct AC_CPDResEnergyTransferMode {
+    RationalNumber max_charge_power;
+    std::optional<RationalNumber> max_charge_power_L2;
+    std::optional<RationalNumber> max_charge_power_L3;
+    RationalNumber min_charge_power;
+    std::optional<RationalNumber> min_charge_power_L2;
+    std::optional<RationalNumber> min_charge_power_L3;
+    RationalNumber nominal_frequency;
+    std::optional<RationalNumber> max_power_asymmetry;
+    std::optional<RationalNumber> power_ramp_limitation;
+    std::optional<RationalNumber> present_active_power;
+    std::optional<RationalNumber> present_active_power_L2;
+    std::optional<RationalNumber> present_active_power_L3;
+};
+
+struct BPT_AC_CPDResEnergyTransferMode : AC_CPDResEnergyTransferMode {
+    RationalNumber max_discharge_power;
+    std::optional<RationalNumber> max_discharge_power_L2;
+    std::optional<RationalNumber> max_discharge_power_L3;
+    RationalNumber min_discharge_power;
+    std::optional<RationalNumber> min_discharge_power_L2;
+    std::optional<RationalNumber> min_discharge_power_L3;
+};
+
+} // namespace datatypes
+
 struct AC_ChargeParameterDiscoveryRequest {
     Header header;
-
-    struct AC_CPDReqEnergyTransferMode {
-        RationalNumber max_charge_power;
-        std::optional<RationalNumber> max_charge_power_L2;
-        std::optional<RationalNumber> max_charge_power_L3;
-        RationalNumber min_charge_power;
-        std::optional<RationalNumber> min_charge_power_L2;
-        std::optional<RationalNumber> min_charge_power_L3;
-    };
-
-    struct BPT_AC_CPDReqEnergyTransferMode : AC_CPDReqEnergyTransferMode {
-        RationalNumber max_discharge_power;
-        std::optional<RationalNumber> max_discharge_power_L2;
-        std::optional<RationalNumber> max_discharge_power_L3;
-        RationalNumber min_discharge_power;
-        std::optional<RationalNumber> min_discharge_power_L2;
-        std::optional<RationalNumber> min_discharge_power_L3;
-    };
-
-    std::variant<AC_CPDReqEnergyTransferMode, BPT_AC_CPDReqEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::AC_CPDReqEnergyTransferMode, datatypes::BPT_AC_CPDReqEnergyTransferMode> transfer_mode;
 };
 
 struct AC_ChargeParameterDiscoveryResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    AC_ChargeParameterDiscoveryResponse() : transfer_mode(std::in_place_type<AC_CPDResEnergyTransferMode>){};
+    AC_ChargeParameterDiscoveryResponse() : transfer_mode(std::in_place_type<datatypes::AC_CPDResEnergyTransferMode>){};
 
-    struct AC_CPDResEnergyTransferMode {
-        RationalNumber max_charge_power;
-        std::optional<RationalNumber> max_charge_power_L2;
-        std::optional<RationalNumber> max_charge_power_L3;
-        RationalNumber min_charge_power;
-        std::optional<RationalNumber> min_charge_power_L2;
-        std::optional<RationalNumber> min_charge_power_L3;
-        RationalNumber nominal_frequency;
-        std::optional<RationalNumber> max_power_asymmetry;
-        std::optional<RationalNumber> power_ramp_limitation;
-        std::optional<RationalNumber> present_active_power;
-        std::optional<RationalNumber> present_active_power_L2;
-        std::optional<RationalNumber> present_active_power_L3;
-    };
-
-    struct BPT_AC_CPDResEnergyTransferMode : AC_CPDResEnergyTransferMode {
-        RationalNumber max_discharge_power;
-        std::optional<RationalNumber> max_discharge_power_L2;
-        std::optional<RationalNumber> max_discharge_power_L3;
-        RationalNumber min_discharge_power;
-        std::optional<RationalNumber> min_discharge_power_L2;
-        std::optional<RationalNumber> min_discharge_power_L3;
-    };
-
-    std::variant<AC_CPDResEnergyTransferMode, BPT_AC_CPDResEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::AC_CPDResEnergyTransferMode, datatypes::BPT_AC_CPDResEnergyTransferMode> transfer_mode;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/authorization.hpp
+++ b/include/iso15118/message/authorization.hpp
@@ -2,13 +2,15 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
+
+namespace datatypes {
 
 enum class AuthStatus {
     Accepted = 0,
@@ -16,37 +18,28 @@ enum class AuthStatus {
     Rejected = 2,
 };
 
+struct EIM_ASReqAuthorizationMode {};
+
+struct PnC_ASReqAuthorizationMode {
+    std::string id;
+    GenChallenge gen_challenge;
+    ContractCertificateChain contract_certificate_chain;
+};
+
+} // namespace datatypes
+
 struct AuthorizationRequest {
-
-    // Todo(sl): Refactor in common
-    struct ContractCertificateChain {
-        struct Certificate {
-            std::vector<uint8_t> certificate;
-        };
-        Certificate certificate;
-        std::vector<Certificate> sub_certificates;
-    };
-
-    struct EIM_ASReqAuthorizationMode {};
-    struct PnC_ASReqAuthorizationMode {
-        std::string id;
-        std::vector<uint8_t> gen_challenge;
-        ContractCertificateChain contract_certificate_chain;
-    };
-
     Header header;
-    Authorization selected_authorization_service;
-    std::optional<EIM_ASReqAuthorizationMode> eim_as_req_authorization_mode;
-    std::optional<PnC_ASReqAuthorizationMode> pnc_as_req_authorization_mode;
+    datatypes::Authorization selected_authorization_service;
+    std::variant<datatypes::EIM_ASReqAuthorizationMode, datatypes::PnC_ASReqAuthorizationMode> authorization_mode;
 };
 
 struct AuthorizationResponse {
-
-    AuthorizationResponse() : evse_processing(Processing::Finished){};
+    AuthorizationResponse() : evse_processing(datatypes::Processing::Finished){};
 
     Header header;
-    ResponseCode response_code;
-    Processing evse_processing;
+    datatypes::ResponseCode response_code;
+    datatypes::Processing evse_processing;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/authorization_setup.hpp
+++ b/include/iso15118/message/authorization_setup.hpp
@@ -8,35 +8,37 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
+
+namespace datatypes {
+using SupportedProvidersList = std::vector<Name>; // [0 - 128]
+
+struct EIM_ASResAuthorizationMode {};
+struct PnC_ASResAuthorizationMode {
+    GenChallenge gen_challenge;
+    std::optional<datatypes::SupportedProvidersList> supported_providers;
+};
+
+} // namespace datatypes
 
 struct AuthorizationSetupRequest {
     Header header;
 };
 
 struct AuthorizationSetupResponse {
-
-    static constexpr auto GEN_CHALLENGE_LENGTH = 16;
-
     AuthorizationSetupResponse() :
-        authorization_services({Authorization::EIM}),
+        authorization_services({datatypes::Authorization::EIM}),
         certificate_installation_service(false),
-        authorization_mode(std::in_place_type<AuthorizationSetupResponse::EIM_ASResAuthorizationMode>){};
+        authorization_mode(std::in_place_type<datatypes::EIM_ASResAuthorizationMode>){};
 
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    struct EIM_ASResAuthorizationMode {};
-    struct PnC_ASResAuthorizationMode {
-        std::array<uint8_t, GEN_CHALLENGE_LENGTH> gen_challenge;
-        std::optional<std::vector<std::string>> supported_providers;
-    };
-
-    std::vector<Authorization> authorization_services;
+    std::vector<datatypes::Authorization> authorization_services;
     bool certificate_installation_service;
-    std::variant<EIM_ASResAuthorizationMode, PnC_ASResAuthorizationMode> authorization_mode;
+    std::variant<datatypes::EIM_ASResAuthorizationMode, datatypes::PnC_ASResAuthorizationMode> authorization_mode;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_cable_check.hpp
+++ b/include/iso15118/message/dc_cable_check.hpp
@@ -2,7 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
@@ -12,12 +12,12 @@ struct DC_CableCheckRequest {
 
 struct DC_CableCheckResponse {
 
-    DC_CableCheckResponse() : processing(Processing::Ongoing){};
+    DC_CableCheckResponse() : processing(datatypes::Processing::Ongoing){};
 
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    Processing processing;
+    datatypes::Processing processing;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_charge_loop.hpp
+++ b/include/iso15118/message/dc_charge_loop.hpp
@@ -5,104 +5,108 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+struct Scheduled_DC_CLReqControlMode : Scheduled_CLReqControlMode {
+    RationalNumber target_current;
+    RationalNumber target_voltage;
+    std::optional<RationalNumber> max_charge_power;
+    std::optional<RationalNumber> min_charge_power;
+    std::optional<RationalNumber> max_charge_current;
+    std::optional<RationalNumber> max_voltage;
+    std::optional<RationalNumber> min_voltage;
+};
+
+struct BPT_Scheduled_DC_CLReqControlMode : Scheduled_DC_CLReqControlMode {
+    std::optional<RationalNumber> max_discharge_power;
+    std::optional<RationalNumber> min_discharge_power;
+    std::optional<RationalNumber> max_discharge_current;
+};
+
+struct Dynamic_DC_CLReqControlMode : Dynamic_CLReqControlMode {
+    RationalNumber max_charge_power;
+    RationalNumber min_charge_power;
+    RationalNumber max_charge_current;
+    RationalNumber max_voltage;
+    RationalNumber min_voltage;
+};
+
+struct BPT_Dynamic_DC_CLReqControlMode : Dynamic_DC_CLReqControlMode {
+    RationalNumber max_discharge_power;
+    RationalNumber min_discharge_power;
+    RationalNumber max_discharge_current;
+    std::optional<RationalNumber> max_v2x_energy_request;
+    std::optional<RationalNumber> min_v2x_energy_request;
+};
+
+struct Scheduled_DC_CLResControlMode : Scheduled_CLResControlMode {
+    std::optional<RationalNumber> max_charge_power;
+    std::optional<RationalNumber> min_charge_power;
+    std::optional<RationalNumber> max_charge_current;
+    std::optional<RationalNumber> max_voltage;
+};
+
+struct BPT_Scheduled_DC_CLResControlMode : Scheduled_DC_CLResControlMode {
+    std::optional<RationalNumber> max_discharge_power;
+    std::optional<RationalNumber> min_discharge_power;
+    std::optional<RationalNumber> max_discharge_current;
+    std::optional<RationalNumber> min_voltage;
+};
+
+struct Dynamic_DC_CLResControlMode : Dynamic_CLResControlMode {
+    RationalNumber max_charge_power;
+    RationalNumber min_charge_power;
+    RationalNumber max_charge_current;
+    RationalNumber max_voltage;
+};
+
+struct BPT_Dynamic_DC_CLResControlMode : Dynamic_DC_CLResControlMode {
+    RationalNumber max_discharge_power;
+    RationalNumber min_discharge_power;
+    RationalNumber max_discharge_current;
+    RationalNumber min_voltage;
+};
+
+} // namespace datatypes
+
 struct DC_ChargeLoopRequest {
-    struct Scheduled_DC_CLReqControlMode : Scheduled_CLReqControlMode {
-        RationalNumber target_current;
-        RationalNumber target_voltage;
-        std::optional<RationalNumber> max_charge_power;
-        std::optional<RationalNumber> min_charge_power;
-        std::optional<RationalNumber> max_charge_current;
-        std::optional<RationalNumber> max_voltage;
-        std::optional<RationalNumber> min_voltage;
-    };
-
-    struct BPT_Scheduled_DC_CLReqControlMode : Scheduled_DC_CLReqControlMode {
-        std::optional<RationalNumber> max_discharge_power;
-        std::optional<RationalNumber> min_discharge_power;
-        std::optional<RationalNumber> max_discharge_current;
-    };
-
-    struct Dynamic_DC_CLReqControlMode : Dynamic_CLReqControlMode {
-        RationalNumber max_charge_power;
-        RationalNumber min_charge_power;
-        RationalNumber max_charge_current;
-        RationalNumber max_voltage;
-        RationalNumber min_voltage;
-    };
-
-    struct BPT_Dynamic_DC_CLReqControlMode : Dynamic_DC_CLReqControlMode {
-        RationalNumber max_discharge_power;
-        RationalNumber min_discharge_power;
-        RationalNumber max_discharge_current;
-        std::optional<RationalNumber> max_v2x_energy_request;
-        std::optional<RationalNumber> min_v2x_energy_request;
-    };
 
     Header header;
 
     // the following 2 are inherited from ChargeLoopReq
-    std::optional<DisplayParameters> display_parameters;
+    std::optional<datatypes::DisplayParameters> display_parameters;
     bool meter_info_requested;
 
-    RationalNumber present_voltage;
-    std::variant<Scheduled_DC_CLReqControlMode, BPT_Scheduled_DC_CLReqControlMode, Dynamic_DC_CLReqControlMode,
-                 BPT_Dynamic_DC_CLReqControlMode>
+    datatypes::RationalNumber present_voltage;
+    std::variant<datatypes::Scheduled_DC_CLReqControlMode, datatypes::BPT_Scheduled_DC_CLReqControlMode,
+                 datatypes::Dynamic_DC_CLReqControlMode, datatypes::BPT_Dynamic_DC_CLReqControlMode>
         control_mode;
 };
 
 struct DC_ChargeLoopResponse {
-
-    struct Scheduled_DC_CLResControlMode : Scheduled_CLResControlMode {
-        std::optional<RationalNumber> max_charge_power;
-        std::optional<RationalNumber> min_charge_power;
-        std::optional<RationalNumber> max_charge_current;
-        std::optional<RationalNumber> max_voltage;
-    };
-
-    struct BPT_Scheduled_DC_CLResControlMode : Scheduled_DC_CLResControlMode {
-        std::optional<RationalNumber> max_discharge_power;
-        std::optional<RationalNumber> min_discharge_power;
-        std::optional<RationalNumber> max_discharge_current;
-        std::optional<RationalNumber> min_voltage;
-    };
-
-    struct Dynamic_DC_CLResControlMode : Dynamic_CLResControlMode {
-        RationalNumber max_charge_power;
-        RationalNumber min_charge_power;
-        RationalNumber max_charge_current;
-        RationalNumber max_voltage;
-    };
-
-    struct BPT_Dynamic_DC_CLResControlMode : Dynamic_DC_CLResControlMode {
-        RationalNumber max_discharge_power;
-        RationalNumber min_discharge_power;
-        RationalNumber max_discharge_current;
-        RationalNumber min_voltage;
-    };
-
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
     // the following 3 are inherited from ChargeLoopRes
-    std::optional<EvseStatus> status;
-    std::optional<MeterInfo> meter_info;
-    std::optional<Receipt> receipt;
+    std::optional<datatypes::EvseStatus> status;
+    std::optional<datatypes::MeterInfo> meter_info;
+    std::optional<datatypes::Receipt> receipt;
 
-    RationalNumber present_current{0, 0};
-    RationalNumber present_voltage{0, 0};
+    datatypes::RationalNumber present_current{0, 0};
+    datatypes::RationalNumber present_voltage{0, 0};
     bool power_limit_achieved{false};
     bool current_limit_achieved{false};
     bool voltage_limit_achieved{false};
 
-    std::variant<Scheduled_DC_CLResControlMode, BPT_Scheduled_DC_CLResControlMode, Dynamic_DC_CLResControlMode,
-                 BPT_Dynamic_DC_CLResControlMode>
+    std::variant<datatypes::Scheduled_DC_CLResControlMode, datatypes::BPT_Scheduled_DC_CLResControlMode,
+                 datatypes::Dynamic_DC_CLResControlMode, datatypes::BPT_Dynamic_DC_CLResControlMode>
         control_mode;
 
-    DC_ChargeLoopResponse() : control_mode(std::in_place_type<DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode>){};
+    DC_ChargeLoopResponse() : control_mode(std::in_place_type<datatypes::Scheduled_DC_CLResControlMode>){};
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_charge_parameter_discovery.hpp
+++ b/include/iso15118/message/dc_charge_parameter_discovery.hpp
@@ -5,58 +5,60 @@
 #include <optional>
 #include <variant>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+struct DC_CPDReqEnergyTransferMode {
+    RationalNumber max_charge_power;
+    RationalNumber min_charge_power;
+    RationalNumber max_charge_current;
+    RationalNumber min_charge_current;
+    RationalNumber max_voltage;
+    RationalNumber min_voltage;
+    std::optional<uint8_t> target_soc;
+};
+
+struct BPT_DC_CPDReqEnergyTransferMode : DC_CPDReqEnergyTransferMode {
+    RationalNumber max_discharge_power;
+    RationalNumber min_discharge_power;
+    RationalNumber max_discharge_current;
+    RationalNumber min_discharge_current;
+};
+
+struct DC_CPDResEnergyTransferMode {
+    RationalNumber max_charge_power;
+    RationalNumber min_charge_power;
+    RationalNumber max_charge_current;
+    RationalNumber min_charge_current;
+    RationalNumber max_voltage;
+    RationalNumber min_voltage;
+    std::optional<RationalNumber> power_ramp_limit;
+};
+
+struct BPT_DC_CPDResEnergyTransferMode : DC_CPDResEnergyTransferMode {
+    RationalNumber max_discharge_power;
+    RationalNumber min_discharge_power;
+    RationalNumber max_discharge_current;
+    RationalNumber min_discharge_current;
+};
+
+} // namespace datatypes
+
 struct DC_ChargeParameterDiscoveryRequest {
     Header header;
-
-    struct DC_CPDReqEnergyTransferMode {
-        RationalNumber max_charge_power;
-        RationalNumber min_charge_power;
-        RationalNumber max_charge_current;
-        RationalNumber min_charge_current;
-        RationalNumber max_voltage;
-        RationalNumber min_voltage;
-        std::optional<uint8_t> target_soc;
-    };
-
-    struct BPT_DC_CPDReqEnergyTransferMode : DC_CPDReqEnergyTransferMode {
-        RationalNumber max_discharge_power;
-        RationalNumber min_discharge_power;
-        RationalNumber max_discharge_current;
-        RationalNumber min_discharge_current;
-    };
-
-    std::variant<DC_CPDReqEnergyTransferMode, BPT_DC_CPDReqEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::DC_CPDReqEnergyTransferMode, datatypes::BPT_DC_CPDReqEnergyTransferMode> transfer_mode;
 };
 
 struct DC_ChargeParameterDiscoveryResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    DC_ChargeParameterDiscoveryResponse() :
-        transfer_mode(std::in_place_type<DC_ChargeParameterDiscoveryResponse::DC_CPDResEnergyTransferMode>){};
+    DC_ChargeParameterDiscoveryResponse() : transfer_mode(std::in_place_type<datatypes::DC_CPDResEnergyTransferMode>){};
 
-    struct DC_CPDResEnergyTransferMode {
-        RationalNumber max_charge_power;
-        RationalNumber min_charge_power;
-        RationalNumber max_charge_current;
-        RationalNumber min_charge_current;
-        RationalNumber max_voltage;
-        RationalNumber min_voltage;
-        std::optional<RationalNumber> power_ramp_limit;
-    };
-
-    struct BPT_DC_CPDResEnergyTransferMode : DC_CPDResEnergyTransferMode {
-        RationalNumber max_discharge_power;
-        RationalNumber min_discharge_power;
-        RationalNumber max_discharge_current;
-        RationalNumber min_discharge_current;
-    };
-
-    std::variant<DC_CPDResEnergyTransferMode, BPT_DC_CPDResEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::DC_CPDResEnergyTransferMode, datatypes::BPT_DC_CPDResEnergyTransferMode> transfer_mode;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_pre_charge.hpp
+++ b/include/iso15118/message/dc_pre_charge.hpp
@@ -2,23 +2,23 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
 struct DC_PreChargeRequest {
     Header header;
 
-    Processing processing;
-    RationalNumber present_voltage;
-    RationalNumber target_voltage;
+    datatypes::Processing processing;
+    datatypes::RationalNumber present_voltage;
+    datatypes::RationalNumber target_voltage;
 };
 
 struct DC_PreChargeResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    RationalNumber present_voltage;
+    datatypes::RationalNumber present_voltage;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_welding_detection.hpp
+++ b/include/iso15118/message/dc_welding_detection.hpp
@@ -2,21 +2,21 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
 struct DC_WeldingDetectionRequest {
     Header header;
 
-    Processing processing;
+    datatypes::Processing processing;
 };
 
 struct DC_WeldingDetectionResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    RationalNumber present_voltage;
+    datatypes::RationalNumber present_voltage;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/power_delivery.hpp
+++ b/include/iso15118/message/power_delivery.hpp
@@ -6,64 +6,61 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+enum class Progress {
+    Start,
+    Stop,
+    Standby,
+    ScheduleRenegotiation,
+};
+
+struct Dynamic_EVPPTControlMode {
+    // intentionally left blank
+};
+
+enum class PowerToleranceAcceptance : uint8_t {
+    NotConfirmed,
+    Confirmed,
+};
+
+struct Scheduled_EVPPTControlMode {
+    NumericId selected_schedule;
+    std::optional<PowerToleranceAcceptance> power_tolerance_acceptance;
+};
+
+struct PowerProfile {
+    uint64_t time_anchor;
+    std::variant<Dynamic_EVPPTControlMode, Scheduled_EVPPTControlMode> control_mode;
+    std::vector<PowerScheduleEntry> entries; // maximum 2048
+};
+
+enum class ChannelSelection : uint8_t {
+    Charge,
+    Discharge,
+};
+
+}; // namespace datatypes
+
 struct PowerDeliveryRequest {
-    enum class Progress {
-        Start,
-        Stop,
-        Standby,
-        ScheduleRenegotiation,
-    };
-
-    struct PowerScheduleEntry {
-        uint32_t duration;
-        RationalNumber power;
-        std::optional<RationalNumber> power_l2;
-        std::optional<RationalNumber> power_l3;
-    };
-
-    struct Dynamic_EVPPTControlMode {
-        // intentionally left blank
-    };
-
-    enum class PowerToleranceAcceptance : uint8_t {
-        NotConfirmed,
-        Confirmed,
-    };
-
-    struct Scheduled_EVPPTControlMode {
-        NumericID selected_schedule;
-        std::optional<PowerToleranceAcceptance> power_tolerance_acceptance;
-    };
-
-    struct PowerProfile {
-        uint64_t time_anchor;
-        std::variant<Dynamic_EVPPTControlMode, Scheduled_EVPPTControlMode> control_mode;
-        std::vector<PowerScheduleEntry> entries; // maximum 2048
-    };
-
-    enum class ChannelSelection : uint8_t {
-        Charge,
-        Discharge,
-    };
-
     Header header;
 
-    Processing processing;
-    Progress charge_progress;
+    datatypes::Processing processing;
+    datatypes::Progress charge_progress;
 
-    std::optional<PowerProfile> power_profile;
-    std::optional<ChannelSelection> channel_selection;
+    std::optional<datatypes::PowerProfile> power_profile;
+    std::optional<datatypes::ChannelSelection> channel_selection;
 };
 
 struct PowerDeliveryResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 
-    std::optional<EvseStatus> status;
+    std::optional<datatypes::EvseStatus> status;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/schedule_exchange.hpp
+++ b/include/iso15118/message/schedule_exchange.hpp
@@ -8,192 +8,201 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+static constexpr auto TAX_RULE_LENGTH = 10;
+static constexpr auto PRICE_RULE_STACK_LENGTH = 1024;
+static constexpr auto PRICE_RULE_LENGTH = 8;
+static constexpr auto OVERSTAY_RULE_LENGTH = 5;
+static constexpr auto ADDITIONAL_SERVICE_LENGTH = 5;
+static constexpr auto PRICE_LEVEL_SCHEDULE_LENGTH = 1024;
+static constexpr auto SCHEDULED_POWER_DURATION_S = 86400;
+
+using MaxSupportingPointsScheduleTuple = uint16_t; // needs to be [12 - 1024]
+
+using Curreny = std::string;  // MaxLength: 3
+using Language = std::string; // MaxLength: 3
+
+struct TaxRule {
+    NumericId tax_rule_id;
+    std::optional<Name> tax_rule_name;
+    RationalNumber tax_rate;
+    std::optional<bool> tax_included_in_price;
+    bool applies_to_energy_fee;
+    bool applies_to_parking_fee;
+    bool applies_to_overstay_fee;
+    bool applies_to_minimum_maximum_cost;
+};
+
+struct PriceRule {
+    RationalNumber energy_fee;
+    std::optional<RationalNumber> parking_fee;
+    std::optional<uint32_t> parking_fee_period;
+    std::optional<uint16_t> carbon_dioxide_emission;
+    std::optional<uint8_t> renewable_generation_percentage;
+    RationalNumber power_range_start;
+};
+
+struct PriceRuleStack {
+    uint32_t duration;
+    std::array<PriceRule, PRICE_RULE_LENGTH> price_rule;
+};
+
+struct AdditionalService {
+    Name service_name;
+    RationalNumber service_fee;
+};
+
+using TaxRuleList = std::array<TaxRule, TAX_RULE_LENGTH>;
+using PriceRuleStackList = std::array<PriceRuleStack, PRICE_RULE_STACK_LENGTH>;
+using AdditionalServiceList = std::array<AdditionalService, ADDITIONAL_SERVICE_LENGTH>;
+
+struct Dynamic_SEReqControlMode {
+    uint32_t departure_time;
+    std::optional<PercentValue> minimum_soc;
+    std::optional<PercentValue> target_soc;
+    RationalNumber target_energy;
+    RationalNumber max_energy;
+    RationalNumber min_energy;
+    std::optional<RationalNumber> max_v2x_energy;
+    std::optional<RationalNumber> min_v2x_energy;
+};
+
+struct EVPowerScheduleEntry {
+    uint32_t duration;
+    RationalNumber power;
+};
+
+struct EVPowerSchedule {
+    uint64_t time_anchor;
+    std::vector<EVPowerScheduleEntry> entries; // max 1024
+};
+
+struct EVPriceRule {
+    RationalNumber energy_fee;
+    RationalNumber power_range_start;
+};
+
+struct EVPriceRuleStack {
+    uint32_t duration;
+    std::vector<EVPriceRule> price_rules; // max 8
+};
+
+struct EVAbsolutePriceSchedule {
+    uint64_t time_anchor;
+    Curreny currency;
+    Identifier price_algorithm;
+    std::vector<EVPriceRuleStack> price_rule_stacks; // max 1024
+};
+
+struct EVEnergyOffer {
+    EVPowerSchedule power_schedule;
+    EVAbsolutePriceSchedule absolute_price_schedule;
+};
+
+struct Scheduled_SEReqControlMode {
+    std::optional<uint32_t> departure_time;
+    std::optional<RationalNumber> target_energy;
+    std::optional<RationalNumber> max_energy;
+    std::optional<RationalNumber> min_energy;
+    std::optional<EVEnergyOffer> energy_offer;
+};
+
+struct OverstayRule {
+    std::optional<Description> overstay_rule_description;
+    uint32_t start_time;
+    RationalNumber overstay_fee;
+    uint32_t overstay_fee_period;
+};
+
+struct OverstayRulesList {
+    std::optional<uint32_t> overstay_time_threshold;
+    std::optional<RationalNumber> overstay_power_threshold;
+    std::vector<OverstayRule> overstay_rule;
+};
+
+struct AbsolutePriceSchedule {
+    std::optional<std::string> id;
+    uint64_t time_anchor;
+    NumericId price_schedule_id;
+    std::optional<Description> price_schedule_description;
+    Curreny currency;
+    Language language;
+    Identifier price_algorithm;
+    std::optional<RationalNumber> minimum_cost;
+    std::optional<RationalNumber> maximum_cost;
+    std::optional<TaxRuleList> tax_rules;
+    PriceRuleStackList price_rule_stacks;
+    std::optional<OverstayRulesList> overstay_rules;
+    std::optional<AdditionalServiceList> additional_selected_services;
+};
+
+struct PriceLevelScheduleEntry {
+    uint32_t duration;
+    uint8_t price_level;
+};
+
+struct PriceLevelSchedule {
+    std::optional<std::string> id;
+    uint64_t time_anchor;
+    NumericId price_schedule_id;
+    std::optional<Description> price_schedule_description;
+    uint8_t number_of_price_levels;
+    std::vector<PriceLevelScheduleEntry> price_level_schedule_entries;
+};
+
+struct Dynamic_SEResControlMode {
+    std::optional<uint32_t> departure_time;
+    std::optional<PercentValue> minimum_soc;
+    std::optional<PercentValue> target_soc;
+    std::variant<std::monostate, AbsolutePriceSchedule, PriceLevelSchedule> price_schedule;
+};
+
+struct PowerSchedule {
+    uint64_t time_anchor;
+    std::optional<RationalNumber> available_energy;
+    std::optional<RationalNumber> power_tolerance;
+    std::vector<PowerScheduleEntry> entries;
+};
+
+struct ChargingSchedule {
+    PowerSchedule power_schedule;
+    std::variant<std::monostate, AbsolutePriceSchedule, PriceLevelSchedule> price_schedule;
+};
+
+struct ScheduleTuple {
+    NumericId schedule_tuple_id; // 1 - 255
+    ChargingSchedule charging_schedule;
+    std::optional<ChargingSchedule> discharging_schedule;
+};
+
+struct Scheduled_SEResControlMode {
+    std::vector<ScheduleTuple> schedule_tuple;
+};
+
+}; // namespace datatypes
+
 struct ScheduleExchangeRequest {
-
-    struct Dynamic_SEReqControlMode {
-        uint32_t departure_time;
-        std::optional<PercentValue> minimum_soc;
-        std::optional<PercentValue> target_soc;
-        RationalNumber target_energy;
-        RationalNumber max_energy;
-        RationalNumber min_energy;
-        std::optional<RationalNumber> max_v2x_energy;
-        std::optional<RationalNumber> min_v2x_energy;
-    };
-
-    struct EVPowerScheduleEntry {
-        uint32_t duration;
-        RationalNumber power;
-    };
-
-    struct EVPowerSchedule {
-        uint64_t time_anchor;
-        std::vector<EVPowerScheduleEntry> entries; // max 1024
-    };
-
-    struct EVPriceRule {
-        RationalNumber energy_fee;
-        RationalNumber power_range_start;
-    };
-
-    struct EVPriceRuleStack {
-        uint32_t duration;
-        std::vector<EVPriceRule> price_rules; // max 8
-    };
-
-    struct EVAbsolutePriceSchedule {
-        uint64_t time_anchor;
-        std::string currency;
-        std::string price_algorithm;
-        std::vector<EVPriceRuleStack> price_rule_stacks; // max 1024
-    };
-
-    struct EVEnergyOffer {
-        EVPowerSchedule power_schedule;
-        EVAbsolutePriceSchedule absolute_price_schedule;
-    };
-
-    struct Scheduled_SEReqControlMode {
-        std::optional<uint32_t> departure_time;
-        std::optional<RationalNumber> target_energy;
-        std::optional<RationalNumber> max_energy;
-        std::optional<RationalNumber> min_energy;
-        std::optional<EVEnergyOffer> energy_offer;
-    };
-
     Header header;
-
-    uint16_t max_supporting_points; // needs to be [12 - 1024]
-    std::variant<Dynamic_SEReqControlMode, Scheduled_SEReqControlMode> control_mode;
+    datatypes::MaxSupportingPointsScheduleTuple max_supporting_points;
+    std::variant<datatypes::Dynamic_SEReqControlMode, datatypes::Scheduled_SEReqControlMode> control_mode;
 };
 
 struct ScheduleExchangeResponse {
-
-    static constexpr auto SCHEDULED_POWER_DURATION_S = 86400;
+    ScheduleExchangeResponse() :
+        processing(datatypes::Processing::Finished),
+        control_mode(std::in_place_type<datatypes::Dynamic_SEResControlMode>){};
 
     Header header;
-    ResponseCode response_code;
-
-    ScheduleExchangeResponse() :
-        processing(Processing::Finished), control_mode(std::in_place_type<Dynamic_SEResControlMode>){};
-
-    Processing processing;
+    datatypes::ResponseCode response_code;
+    datatypes::Processing processing;
     std::optional<bool> go_to_pause;
 
-    struct TaxRule {
-        uint32_t tax_rule_id;
-        std::optional<std::string> tax_rule_name;
-        RationalNumber tax_rate;
-        std::optional<bool> tax_included_in_price;
-        bool applies_to_energy_fee;
-        bool applies_to_parking_fee;
-        bool applies_to_overstay_fee;
-        bool applies_to_minimum_maximum_cost;
-    };
-
-    struct PriceRule {
-        RationalNumber energy_fee;
-        std::optional<RationalNumber> parking_fee;
-        std::optional<uint32_t> parking_fee_period;
-        std::optional<uint16_t> carbon_dioxide_emission;
-        std::optional<uint8_t> renewable_generation_percentage;
-        RationalNumber power_range_start;
-    };
-
-    struct PriceRuleStack {
-        uint32_t duration;
-        std::vector<PriceRule> price_rule;
-    };
-
-    struct OverstayRule {
-        std::optional<std::string> overstay_rule_description;
-        uint32_t start_time;
-        RationalNumber overstay_fee;
-        uint32_t overstay_fee_period;
-    };
-
-    struct OverstayRulesList {
-        std::optional<uint32_t> overstay_time_threshold;
-        std::optional<RationalNumber> overstay_power_threshold;
-        std::vector<OverstayRule> overstay_rule;
-    };
-
-    struct AdditionalService {
-        std::string service_name;
-        RationalNumber service_fee;
-    };
-
-    struct AbsolutePriceSchedule {
-        std::optional<std::string> id;
-        uint64_t time_anchor;
-        uint32_t price_schedule_id;
-        std::optional<std::string> price_schedule_description;
-        std::string currency;
-        std::string language;
-        std::string price_algorithm;
-        std::optional<RationalNumber> minimum_cost;
-        std::optional<RationalNumber> maximum_cost;
-        std::optional<std::vector<TaxRule>> tax_rules;
-        std::vector<PriceRuleStack> price_rule_stacks;
-        std::optional<OverstayRulesList> overstay_rules;
-        std::optional<std::vector<AdditionalService>> additional_selected_services;
-    };
-
-    struct PriceLevelScheduleEntry {
-        uint32_t duration;
-        uint8_t price_level;
-    };
-
-    struct PriceLevelSchedule {
-        std::optional<std::string> id;
-        uint64_t time_anchor;
-        uint32_t price_schedule_id;
-        std::optional<std::string> price_schedule_description;
-        uint8_t number_of_price_levels;
-        std::vector<PriceLevelScheduleEntry> price_level_schedule_entries;
-    };
-
-    struct Dynamic_SEResControlMode {
-        std::optional<uint32_t> departure_time;
-        std::optional<uint8_t> minimum_soc;
-        std::optional<uint8_t> target_soc;
-        std::variant<std::monostate, AbsolutePriceSchedule, PriceLevelSchedule> price_schedule;
-    };
-
-    struct PowerScheduleEntry {
-        uint32_t duration;
-        RationalNumber power;
-        std::optional<RationalNumber> power_l2;
-        std::optional<RationalNumber> power_l3;
-    };
-
-    struct PowerSchedule {
-        uint64_t time_anchor;
-        std::optional<RationalNumber> available_energy;
-        std::optional<RationalNumber> power_tolerance;
-        std::vector<PowerScheduleEntry> entries;
-    };
-
-    struct ChargingSchedule {
-        PowerSchedule power_schedule;
-        std::variant<std::monostate, AbsolutePriceSchedule, PriceLevelSchedule> price_schedule;
-    };
-
-    struct ScheduleTuple {
-        NumericID schedule_tuple_id; // 1 - 255
-        ChargingSchedule charging_schedule;
-        std::optional<ChargingSchedule> discharging_schedule;
-    };
-
-    struct Scheduled_SEResControlMode {
-        std::vector<ScheduleTuple> schedule_tuple;
-    };
-
-    std::variant<Dynamic_SEResControlMode, Scheduled_SEResControlMode> control_mode;
+    std::variant<datatypes::Dynamic_SEResControlMode, datatypes::Scheduled_SEResControlMode> control_mode;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/service_detail.hpp
+++ b/include/iso15118/message/service_detail.hpp
@@ -6,36 +6,42 @@
 #include <variant>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+
+struct Parameter {
+    Name name;
+    std::variant<bool, int8_t, int16_t, int32_t, Name, RationalNumber> value;
+};
+
+struct ParameterSet {
+    uint16_t id;
+    std::vector<Parameter> parameter;
+
+    ParameterSet();
+    ParameterSet(uint16_t _id, const DcParameterList& list);
+    ParameterSet(uint16_t _id, const DcBptParameterList& list);
+    ParameterSet(uint16_t _id, const InternetParameterList& list);
+    ParameterSet(uint16_t _id, const ParkingParameterList& list);
+};
+
+using ServiceParameterList = std::vector<ParameterSet>; // Max: 32
+
+} // namespace datatypes
+
 struct ServiceDetailRequest {
     Header header;
-    ServiceCategory service;
+    datatypes::ServiceCategory service;
 };
 
 struct ServiceDetailResponse {
-    struct Parameter {
-        std::string name;
-        std::variant<bool, int8_t, int16_t, int32_t, std::string, RationalNumber> value;
-    };
-
-    struct ParameterSet {
-        uint16_t id;
-        std::vector<Parameter> parameter;
-
-        ParameterSet();
-        ParameterSet(uint16_t _id, const DcParameterList& list);
-        ParameterSet(uint16_t _id, const DcBptParameterList& list);
-        ParameterSet(uint16_t _id, const InternetParameterList& list);
-        ParameterSet(uint16_t _id, const ParkingParameterList& list);
-    };
-
     Header header;
-    ResponseCode response_code;
-    ServiceCategory service = ServiceCategory::DC;
-    std::vector<ParameterSet> service_parameter_list = {ParameterSet()};
+    datatypes::ResponseCode response_code;
+    datatypes::ServiceCategory service{datatypes::ServiceCategory::DC};
+    datatypes::ServiceParameterList service_parameter_list = {datatypes::ParameterSet()};
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/service_discovery.hpp
+++ b/include/iso15118/message/service_discovery.hpp
@@ -5,29 +5,37 @@
 #include <optional>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
+namespace datatypes {
+using ServiceIdList = std::vector<std::uint16_t>; //
+
+struct Service {
+    ServiceCategory service_id;
+    bool free_service;
+};
+using ServiceList = std::vector<Service>; // max: 8
+
+} // namespace datatypes
+
 struct ServiceDiscoveryRequest {
     Header header;
-    std::optional<std::vector<uint16_t>> supported_service_ids;
+    std::optional<datatypes::ServiceIdList> supported_service_ids;
 };
 
 struct ServiceDiscoveryResponse {
-    struct Service {
-        ServiceCategory service_id;
-        bool free_service;
-    };
 
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
     bool service_renegotiation_supported = false;
-    std::vector<Service> energy_transfer_service_list = {{
-        ServiceCategory::AC, // service_id
-        false                // free_service
+    // FIXME(sl): Adding constructor
+    datatypes::ServiceList energy_transfer_service_list = {{
+        datatypes::ServiceCategory::AC, // service_id
+        false                           // free_service
     }};
-    std::optional<std::vector<Service>> vas_list;
+    std::optional<datatypes::ServiceList> vas_list;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/service_selection.hpp
+++ b/include/iso15118/message/service_selection.hpp
@@ -5,24 +5,30 @@
 #include <optional>
 #include <vector>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
-struct ServiceSelectionRequest {
-    struct SelectedService {
-        ServiceCategory service_id;
-        int16_t parameter_set_id;
-    };
+namespace datatypes {
 
+struct SelectedService {
+    ServiceCategory service_id;
+    uint16_t parameter_set_id;
+};
+
+using SelectedServiceList = std::vector<SelectedService>; // Max: 16
+
+} // namespace datatypes
+
+struct ServiceSelectionRequest {
     Header header;
-    SelectedService selected_energy_transfer_service;
-    std::optional<std::vector<SelectedService>> selected_vas_list;
+    datatypes::SelectedService selected_energy_transfer_service;
+    std::optional<datatypes::SelectedServiceList> selected_vas_list;
 };
 
 struct ServiceSelectionResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/session_setup.hpp
+++ b/include/iso15118/message/session_setup.hpp
@@ -4,19 +4,19 @@
 
 #include <string>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
 struct SessionSetupRequest {
     Header header;
-    std::string evccid;
+    datatypes::Identifier evccid;
 };
 
 struct SessionSetupResponse {
     Header header;
-    ResponseCode response_code;
-    std::string evseid;
+    datatypes::ResponseCode response_code;
+    datatypes::Identifier evseid;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/session_stop.hpp
+++ b/include/iso15118/message/session_stop.hpp
@@ -5,20 +5,20 @@
 #include <optional>
 #include <string>
 
-#include "common.hpp"
+#include "common_types.hpp"
 
 namespace iso15118::message_20 {
 
 struct SessionStopRequest {
     Header header;
-    ChargingSession charging_session;
-    std::optional<std::string> ev_termination_code;
-    std::optional<std::string> ev_termination_explanation;
+    datatypes::ChargingSession charging_session;
+    std::optional<datatypes::Name> ev_termination_code;
+    std::optional<datatypes::Description> ev_termination_explanation;
 };
 
 struct SessionStopResponse {
     Header header;
-    ResponseCode response_code;
+    datatypes::ResponseCode response_code;
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/session/feedback.hpp
+++ b/include/iso15118/session/feedback.hpp
@@ -33,15 +33,14 @@ struct DcMaximumLimits {
     float power{NAN};
 };
 
-using PresentVoltage = message_20::RationalNumber;
+using PresentVoltage = message_20::datatypes::RationalNumber;
 using MeterInfoRequested = bool;
-using DcReqControlMode = std::variant<message_20::DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode,
-                                      message_20::DC_ChargeLoopRequest::BPT_Scheduled_DC_CLReqControlMode,
-                                      message_20::DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode,
-                                      message_20::DC_ChargeLoopRequest::BPT_Dynamic_DC_CLReqControlMode>;
+using DcReqControlMode = std::variant<
+    message_20::datatypes::Scheduled_DC_CLReqControlMode, message_20::datatypes::BPT_Scheduled_DC_CLReqControlMode,
+    message_20::datatypes::Dynamic_DC_CLReqControlMode, message_20::datatypes::BPT_Dynamic_DC_CLReqControlMode>;
 
 using DcChargeLoopReq =
-    std::variant<DcReqControlMode, message_20::DisplayParameters, PresentVoltage, MeterInfoRequested>;
+    std::variant<DcReqControlMode, message_20::datatypes::DisplayParameters, PresentVoltage, MeterInfoRequested>;
 
 struct Callbacks {
     std::function<void(Signal)> signal;

--- a/include/iso15118/tbd_controller.hpp
+++ b/include/iso15118/tbd_controller.hpp
@@ -13,7 +13,7 @@
 #include <iso15118/d20/limits.hpp>
 #include <iso15118/io/poll_manager.hpp>
 #include <iso15118/io/sdp_server.hpp>
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 #include <iso15118/session/feedback.hpp>
 #include <iso15118/session/iso.hpp>
 
@@ -34,7 +34,7 @@ public:
 
     void send_control_event(const d20::ControlEvent&);
 
-    void update_authorization_services(const std::vector<message_20::Authorization>& services,
+    void update_authorization_services(const std::vector<message_20::datatypes::Authorization>& services,
                                        bool cert_install_service);
     void update_dc_limits(const d20::DcTransferLimits&);
 

--- a/src/iso15118/CMakeLists.txt
+++ b/src/iso15118/CMakeLists.txt
@@ -49,7 +49,7 @@ target_sources(iso15118
         message/variant.cpp
         message/supported_app_protocol.cpp
         message/session_setup.cpp
-        message/common.cpp
+        message/common_types.cpp
         message/authorization_setup.cpp
         message/authorization.cpp
         message/service_discovery.cpp

--- a/src/iso15118/d20/config.cpp
+++ b/src/iso15118/d20/config.cpp
@@ -8,10 +8,12 @@
 
 namespace iso15118::d20 {
 
+namespace dt = message_20::datatypes;
+
 namespace {
 
 auto get_mobility_needs_mode(const ControlMobilityNeedsModes& mode) {
-    using namespace message_20;
+    using namespace dt;
 
     if (mode.control_mode == ControlMode::Scheduled and mode.mobility_mode == MobilityNeedsMode::ProvidedBySecc) {
         logf_info("Setting the mobility needs mode to ProvidedByEvcc. In scheduled mode only ProvidedByEvcc is "
@@ -23,7 +25,7 @@ auto get_mobility_needs_mode(const ControlMobilityNeedsModes& mode) {
 }
 
 auto get_default_dc_parameter_list(const std::vector<ControlMobilityNeedsModes>& control_mobility_modes) {
-    using namespace message_20;
+    using namespace dt;
 
     // TODO(sl): Add check if a control mode is more than one in that vector
 
@@ -42,7 +44,7 @@ auto get_default_dc_parameter_list(const std::vector<ControlMobilityNeedsModes>&
 }
 
 auto get_default_dc_bpt_parameter_list(const std::vector<ControlMobilityNeedsModes>& control_mobility_modes) {
-    using namespace message_20;
+    using namespace dt;
 
     // TODO(sl): Add check if a control mode is more than one in that vector
 
@@ -72,9 +74,7 @@ SessionConfig::SessionConfig(EvseSetupConfig config) :
     dc_limits(std::move(config.dc_limits)),
     supported_control_mobility_modes(std::move(config.control_mobility_modes)) {
 
-    const auto is_bpt_service = [](message_20::ServiceCategory service) {
-        return service == message_20::ServiceCategory::DC_BPT;
-    };
+    const auto is_bpt_service = [](dt::ServiceCategory service) { return service == dt::ServiceCategory::DC_BPT; };
     const auto dc_bpt_found = std::any_of(supported_energy_transfer_services.begin(),
                                           supported_energy_transfer_services.end(), is_bpt_service);
 
@@ -85,8 +85,7 @@ SessionConfig::SessionConfig(EvseSetupConfig config) :
 
     if (supported_control_mobility_modes.empty()) {
         logf_warning("No control modes were provided, set to scheduled mode");
-        supported_control_mobility_modes = {
-            {message_20::ControlMode::Scheduled, message_20::MobilityNeedsMode::ProvidedByEvcc}};
+        supported_control_mobility_modes = {{dt::ControlMode::Scheduled, dt::MobilityNeedsMode::ProvidedByEvcc}};
     }
 
     dc_parameter_list = get_default_dc_parameter_list(supported_control_mobility_modes);

--- a/src/iso15118/d20/context_helper.cpp
+++ b/src/iso15118/d20/context_helper.cpp
@@ -42,7 +42,7 @@ void setup_header(message_20::Header& header, const Session& cur_session) {
 template <typename Response> Response handle_sequence_error(const d20::Session& session) {
     Response res;
     setup_header(res.header, session);
-    return response_with_code(res, message_20::ResponseCode::FAILED_SequenceError);
+    return response_with_code(res, message_20::datatypes::ResponseCode::FAILED_SequenceError);
 }
 
 // Todo(sl): Not happy at all. Need refactoring. Only ctx.respond and Session is needed. Not the whole Context.

--- a/src/iso15118/d20/session.cpp
+++ b/src/iso15118/d20/session.cpp
@@ -8,6 +8,8 @@
 
 namespace iso15118::d20 {
 
+namespace dt = message_20::datatypes;
+
 Session::Session() {
     std::random_device rd;
     std::mt19937 generator(rd());
@@ -39,31 +41,31 @@ Session::Session(OfferedServices services_) : offered_services(services_) {
 
 Session::~Session() = default;
 
-bool Session::find_parameter_set_id(const message_20::ServiceCategory service, int16_t id) {
+bool Session::find_parameter_set_id(const dt::ServiceCategory service, int16_t id) {
 
     switch (service) {
-    case message_20::ServiceCategory::DC:
+    case dt::ServiceCategory::DC:
 
         if (this->offered_services.dc_parameter_list.find(id) != this->offered_services.dc_parameter_list.end()) {
             return true;
         }
         break;
 
-    case message_20::ServiceCategory::DC_BPT:
+    case dt::ServiceCategory::DC_BPT:
         if (this->offered_services.dc_bpt_parameter_list.find(id) !=
             this->offered_services.dc_bpt_parameter_list.end()) {
             return true;
         }
         break;
 
-    case message_20::ServiceCategory::Internet:
+    case dt::ServiceCategory::Internet:
         if (this->offered_services.internet_parameter_list.find(id) !=
             this->offered_services.internet_parameter_list.end()) {
             return true;
         }
         break;
 
-    case message_20::ServiceCategory::ParkingStatus:
+    case dt::ServiceCategory::ParkingStatus:
         if (this->offered_services.parking_parameter_list.find(id) !=
             this->offered_services.parking_parameter_list.end()) {
             return true;
@@ -77,57 +79,57 @@ bool Session::find_parameter_set_id(const message_20::ServiceCategory service, i
     return false;
 }
 
-void Session::selected_service_parameters(const message_20::ServiceCategory service, const uint16_t id) {
+void Session::selected_service_parameters(const dt::ServiceCategory service, const uint16_t id) {
 
     switch (service) {
-    case message_20::ServiceCategory::DC:
+    case dt::ServiceCategory::DC:
 
         if (this->offered_services.dc_parameter_list.find(id) != this->offered_services.dc_parameter_list.end()) {
             auto& parameters = this->offered_services.dc_parameter_list.at(id);
             this->selected_services =
-                SelectedServiceParameters(message_20::ServiceCategory::DC, parameters.connector,
-                                          parameters.control_mode, parameters.mobility_needs_mode, parameters.pricing);
+                SelectedServiceParameters(dt::ServiceCategory::DC, parameters.connector, parameters.control_mode,
+                                          parameters.mobility_needs_mode, parameters.pricing);
 
             logf_info("Selected DC service parameters: control mode: %s, mobility needs mode: %s",
-                      message_20::from_control_mode(parameters.control_mode).c_str(),
-                      message_20::from_mobility_needs_mode(parameters.mobility_needs_mode).c_str());
+                      dt::from_control_mode(parameters.control_mode).c_str(),
+                      dt::from_mobility_needs_mode(parameters.mobility_needs_mode).c_str());
         } else {
             // Todo(sl): Should be not the case -> Raise Error?
         }
         break;
 
-    case message_20::ServiceCategory::DC_BPT:
+    case dt::ServiceCategory::DC_BPT:
         if (this->offered_services.dc_bpt_parameter_list.find(id) !=
             this->offered_services.dc_bpt_parameter_list.end()) {
             auto& parameters = this->offered_services.dc_bpt_parameter_list.at(id);
             this->selected_services = SelectedServiceParameters(
-                message_20::ServiceCategory::DC_BPT, parameters.connector, parameters.control_mode,
+                dt::ServiceCategory::DC_BPT, parameters.connector, parameters.control_mode,
                 parameters.mobility_needs_mode, parameters.pricing, parameters.bpt_channel, parameters.generator_mode);
 
             logf_info("Selected DC_BPT service parameters: control mode: %s, mobility needs mode: %s",
-                      message_20::from_control_mode(parameters.control_mode).c_str(),
-                      message_20::from_mobility_needs_mode(parameters.mobility_needs_mode).c_str());
+                      dt::from_control_mode(parameters.control_mode).c_str(),
+                      dt::from_mobility_needs_mode(parameters.mobility_needs_mode).c_str());
         } else {
             // Todo(sl): Should be not the case -> Raise Error?
         }
         break;
 
-    case message_20::ServiceCategory::Internet:
+    case dt::ServiceCategory::Internet:
 
         if (this->offered_services.internet_parameter_list.find(id) !=
             this->offered_services.internet_parameter_list.end()) {
-            this->selected_vas_services.vas_services.push_back(message_20::ServiceCategory::Internet);
+            this->selected_vas_services.vas_services.push_back(dt::ServiceCategory::Internet);
             auto& parameters = this->offered_services.internet_parameter_list.at(id);
             this->selected_vas_services.internet_port = parameters.port;
             this->selected_vas_services.internet_protocol = parameters.protocol;
         }
         break;
 
-    case message_20::ServiceCategory::ParkingStatus:
+    case dt::ServiceCategory::ParkingStatus:
 
         if (this->offered_services.parking_parameter_list.find(id) !=
             this->offered_services.parking_parameter_list.end()) {
-            this->selected_vas_services.vas_services.push_back(message_20::ServiceCategory::ParkingStatus);
+            this->selected_vas_services.vas_services.push_back(dt::ServiceCategory::ParkingStatus);
             auto& parameters = this->offered_services.parking_parameter_list.at(id);
             this->selected_vas_services.parking_intended_service = parameters.intended_service;
             this->selected_vas_services.parking_status = parameters.parking_status;

--- a/src/iso15118/d20/state/authorization_setup.cpp
+++ b/src/iso15118/d20/state/authorization_setup.cpp
@@ -13,32 +13,33 @@
 
 namespace iso15118::d20::state {
 
-message_20::AuthorizationSetupResponse
-handle_request(const message_20::AuthorizationSetupRequest& req, d20::Session& session, bool cert_install_service,
-               const std::vector<message_20::Authorization>& authorization_services) {
+namespace dt = message_20::datatypes;
+
+message_20::AuthorizationSetupResponse handle_request(const message_20::AuthorizationSetupRequest& req,
+                                                      d20::Session& session, bool cert_install_service,
+                                                      const std::vector<dt::Authorization>& authorization_services) {
 
     auto res = message_20::AuthorizationSetupResponse(); // default mandatory values [V2G20-736]
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     res.certificate_installation_service = cert_install_service;
 
     if (authorization_services.empty()) {
         logf_warning("authorization_services was not set. Setting EIM as auth_mode");
-        res.authorization_services = {message_20::Authorization::EIM};
+        res.authorization_services = {dt::Authorization::EIM};
     } else {
         res.authorization_services = authorization_services;
     }
 
     session.offered_services.auth_services = res.authorization_services;
 
-    if (res.authorization_services.size() == 1 && res.authorization_services[0] == message_20::Authorization::EIM) {
-        res.authorization_mode.emplace<message_20::AuthorizationSetupResponse::EIM_ASResAuthorizationMode>();
+    if (res.authorization_services.size() == 1 && res.authorization_services[0] == dt::Authorization::EIM) {
+        res.authorization_mode.emplace<dt::EIM_ASResAuthorizationMode>();
     } else {
-        auto& pnc_auth_mode =
-            res.authorization_mode.emplace<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>();
+        auto& pnc_auth_mode = res.authorization_mode.emplace<dt::PnC_ASResAuthorizationMode>();
 
         std::random_device rd;
         std::mt19937 generator(rd());
@@ -49,7 +50,7 @@ handle_request(const message_20::AuthorizationSetupRequest& req, d20::Session& s
         }
     }
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void AuthorizationSetup::enter() {
@@ -72,7 +73,7 @@ FsmSimpleState::HandleEventReturnType AuthorizationSetup::handle_event(Allocator
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/dc_cable_check.cpp
+++ b/src/iso15118/d20/state/dc_cable_check.cpp
@@ -10,22 +10,24 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::DC_CableCheckResponse handle_request(const message_20::DC_CableCheckRequest& req,
                                                  const d20::Session& session, bool cable_check_done) {
 
     message_20::DC_CableCheckResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     if (not cable_check_done) {
-        res.processing = message_20::Processing::Ongoing;
+        res.processing = dt::Processing::Ongoing;
     } else {
-        res.processing = message_20::Processing::Finished;
+        res.processing = dt::Processing::Finished;
     }
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void DC_CableCheck::enter() {
@@ -62,7 +64,7 @@ FsmSimpleState::HandleEventReturnType DC_CableCheck::handle_event(AllocatorType&
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/dc_pre_charge.cpp
+++ b/src/iso15118/d20/state/dc_pre_charge.cpp
@@ -10,18 +10,20 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::DC_PreChargeResponse handle_request(const message_20::DC_PreChargeRequest& req, const d20::Session& session,
                                                 const float present_voltage) {
 
     message_20::DC_PreChargeResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
-    res.present_voltage = message_20::from_float(present_voltage);
+    res.present_voltage = dt::from_float(present_voltage);
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void DC_PreCharge::enter() {
@@ -51,11 +53,11 @@ FsmSimpleState::HandleEventReturnType DC_PreCharge::handle_event(AllocatorType& 
     if (const auto req = variant->get_if<message_20::DC_PreChargeRequest>()) {
         const auto res = handle_request(*req, ctx.session, present_voltage);
 
-        ctx.feedback.dc_pre_charge_target_voltage(message_20::from_RationalNumber(req->target_voltage));
+        ctx.feedback.dc_pre_charge_target_voltage(message_20::datatypes::from_RationalNumber(req->target_voltage));
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/dc_welding_detection.cpp
+++ b/src/iso15118/d20/state/dc_welding_detection.cpp
@@ -9,17 +9,19 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::DC_WeldingDetectionResponse handle_request(const message_20::DC_WeldingDetectionRequest& req,
                                                        const d20::Session& session, const float present_voltage) {
     message_20::DC_WeldingDetectionResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
-    res.present_voltage = message_20::from_float(present_voltage);
+    res.present_voltage = dt::from_float(present_voltage);
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void DC_WeldingDetection::enter() {
@@ -51,12 +53,12 @@ FsmSimpleState::HandleEventReturnType DC_WeldingDetection::handle_event(Allocato
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }
 
-        if (req->processing == message_20::Processing::Ongoing) {
+        if (req->processing == dt::Processing::Ongoing) {
             return sa.HANDLED_INTERNALLY;
         }
 

--- a/src/iso15118/d20/state/service_detail.cpp
+++ b/src/iso15118/d20/state/service_detail.cpp
@@ -11,13 +11,15 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::ServiceDetailResponse handle_request(const message_20::ServiceDetailRequest& req, d20::Session& session,
                                                  const d20::SessionConfig& config) {
 
     message_20::ServiceDetailResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     bool service_found = false;
@@ -37,7 +39,7 @@ message_20::ServiceDetailResponse handle_request(const message_20::ServiceDetail
     }
 
     if (!service_found) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_ServiceIDInvalid);
+        return response_with_code(res, dt::ResponseCode::FAILED_ServiceIDInvalid);
     }
 
     res.service_parameter_list.clear(); // reset default values
@@ -45,47 +47,47 @@ message_20::ServiceDetailResponse handle_request(const message_20::ServiceDetail
     uint8_t id = 0;
 
     switch (req.service) {
-    case message_20::ServiceCategory::DC:
-        res.service = message_20::ServiceCategory::DC;
+    case dt::ServiceCategory::DC:
+        res.service = dt::ServiceCategory::DC;
         for (auto& parameter_set : config.dc_parameter_list) {
             session.offered_services.dc_parameter_list[id] = parameter_set;
-            res.service_parameter_list.push_back(message_20::ServiceDetailResponse::ParameterSet(id++, parameter_set));
+            res.service_parameter_list.push_back(dt::ParameterSet(id++, parameter_set));
         }
         break;
-    case message_20::ServiceCategory::DC_BPT:
-        res.service = message_20::ServiceCategory::DC_BPT;
+    case dt::ServiceCategory::DC_BPT:
+        res.service = dt::ServiceCategory::DC_BPT;
         for (auto& parameter_set : config.dc_bpt_parameter_list) {
             session.offered_services.dc_bpt_parameter_list[id] = parameter_set;
-            res.service_parameter_list.push_back(message_20::ServiceDetailResponse::ParameterSet(id++, parameter_set));
+            res.service_parameter_list.push_back(dt::ParameterSet(id++, parameter_set));
         }
         break;
 
-    case message_20::ServiceCategory::Internet:
-        res.service = message_20::ServiceCategory::Internet;
+    case dt::ServiceCategory::Internet:
+        res.service = dt::ServiceCategory::Internet;
 
         for (auto& parameter_set : config.internet_parameter_list) {
             // TODO(sl): Possibly refactor, define const
-            if (parameter_set.port == message_20::Port::Port20) {
+            if (parameter_set.port == dt::Port::Port20) {
                 id = 1;
-            } else if (parameter_set.port == message_20::Port::Port21) {
+            } else if (parameter_set.port == dt::Port::Port21) {
                 id = 2;
-            } else if (parameter_set.port == message_20::Port::Port80) {
+            } else if (parameter_set.port == dt::Port::Port80) {
                 id = 3;
-            } else if (parameter_set.port == message_20::Port::Port443) {
+            } else if (parameter_set.port == dt::Port::Port443) {
                 id = 4;
             }
             session.offered_services.internet_parameter_list[id] = parameter_set;
-            res.service_parameter_list.push_back(message_20::ServiceDetailResponse::ParameterSet(id, parameter_set));
+            res.service_parameter_list.push_back(dt::ParameterSet(id, parameter_set));
         }
 
         break;
 
-    case message_20::ServiceCategory::ParkingStatus:
-        res.service = message_20::ServiceCategory::ParkingStatus;
+    case dt::ServiceCategory::ParkingStatus:
+        res.service = dt::ServiceCategory::ParkingStatus;
 
         for (auto& parameter_set : config.parking_parameter_list) {
             session.offered_services.parking_parameter_list[id] = parameter_set;
-            res.service_parameter_list.push_back(message_20::ServiceDetailResponse::ParameterSet(id++, parameter_set));
+            res.service_parameter_list.push_back(dt::ParameterSet(id++, parameter_set));
         }
         break;
 
@@ -94,7 +96,7 @@ message_20::ServiceDetailResponse handle_request(const message_20::ServiceDetail
         break;
     }
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void ServiceDetail::enter() {
@@ -116,7 +118,7 @@ FsmSimpleState::HandleEventReturnType ServiceDetail::handle_event(AllocatorType&
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/service_discovery.cpp
+++ b/src/iso15118/d20/state/service_discovery.cpp
@@ -13,19 +13,21 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 static bool find_service_id(const std::vector<uint16_t>& req_service_ids, const uint16_t service) {
     return std::find(req_service_ids.begin(), req_service_ids.end(), service) != req_service_ids.end();
 }
 
 message_20::ServiceDiscoveryResponse handle_request(const message_20::ServiceDiscoveryRequest& req,
                                                     d20::Session& session,
-                                                    const std::vector<message_20::ServiceCategory>& energy_services,
-                                                    const std::vector<message_20::ServiceCategory>& vas_services) {
+                                                    const std::vector<dt::ServiceCategory>& energy_services,
+                                                    const std::vector<dt::ServiceCategory>& vas_services) {
 
-    message_20::ServiceDiscoveryResponse res = message_20::ServiceDiscoveryResponse();
+    message_20::ServiceDiscoveryResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     // Service renegotiation is not yet supported
@@ -35,8 +37,8 @@ message_20::ServiceDiscoveryResponse handle_request(const message_20::ServiceDis
     // Reset default value
     res.energy_transfer_service_list.clear();
 
-    std::vector<message_20::ServiceDiscoveryResponse::Service> energy_services_list;
-    std::vector<message_20::ServiceDiscoveryResponse::Service> vas_services_list;
+    std::vector<dt::Service> energy_services_list;
+    std::vector<dt::Service> vas_services_list;
 
     // EV supported service ID's
     if (req.supported_service_ids.has_value() == true) {
@@ -75,7 +77,7 @@ message_20::ServiceDiscoveryResponse handle_request(const message_20::ServiceDis
         }
     }
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void ServiceDiscovery::enter() {
@@ -102,7 +104,7 @@ FsmSimpleState::HandleEventReturnType ServiceDiscovery::handle_event(AllocatorTy
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/service_selection.cpp
+++ b/src/iso15118/d20/state/service_selection.cpp
@@ -13,13 +13,15 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::ServiceSelectionResponse handle_request(const message_20::ServiceSelectionRequest& req,
                                                     d20::Session& session) {
 
     message_20::ServiceSelectionResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     bool energy_service_found = false;
@@ -33,7 +35,7 @@ message_20::ServiceSelectionResponse handle_request(const message_20::ServiceSel
     }
 
     if (!energy_service_found) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_NoEnergyTransferServiceSelected);
+        return response_with_code(res, dt::ResponseCode::FAILED_NoEnergyTransferServiceSelected);
     }
 
     if (req.selected_vas_list.has_value()) {
@@ -49,13 +51,13 @@ message_20::ServiceSelectionResponse handle_request(const message_20::ServiceSel
         }
 
         if (not vas_services_found) {
-            return response_with_code(res, message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+            return response_with_code(res, dt::ResponseCode::FAILED_ServiceSelectionInvalid);
         }
     }
 
     if (not session.find_parameter_set_id(req.selected_energy_transfer_service.service_id,
                                           req.selected_energy_transfer_service.parameter_set_id)) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+        return response_with_code(res, dt::ResponseCode::FAILED_ServiceSelectionInvalid);
     }
 
     session.selected_service_parameters(req.selected_energy_transfer_service.service_id,
@@ -66,13 +68,13 @@ message_20::ServiceSelectionResponse handle_request(const message_20::ServiceSel
 
         for (auto& vas_service : selected_vas_list) {
             if (not session.find_parameter_set_id(vas_service.service_id, vas_service.parameter_set_id)) {
-                return response_with_code(res, message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+                return response_with_code(res, dt::ResponseCode::FAILED_ServiceSelectionInvalid);
             }
             session.selected_service_parameters(vas_service.service_id, vas_service.parameter_set_id);
         }
     }
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void ServiceSelection::enter() {
@@ -94,7 +96,7 @@ FsmSimpleState::HandleEventReturnType ServiceSelection::handle_event(AllocatorTy
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }
@@ -105,7 +107,7 @@ FsmSimpleState::HandleEventReturnType ServiceSelection::handle_event(AllocatorTy
 
         ctx.respond(res);
 
-        if (res.response_code >= message_20::ResponseCode::FAILED) {
+        if (res.response_code >= dt::ResponseCode::FAILED) {
             ctx.session_stopped = true;
             return sa.PASS_ON;
         }

--- a/src/iso15118/d20/state/session_setup.cpp
+++ b/src/iso15118/d20/state/session_setup.cpp
@@ -15,6 +15,8 @@ static bool session_is_zero(const iso15118::message_20::Header& header) {
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::SessionSetupResponse handle_request([[maybe_unused]] const message_20::SessionSetupRequest& req,
                                                 const d20::Session& session, const std::string& evse_id,
                                                 bool new_session) {
@@ -26,9 +28,9 @@ message_20::SessionSetupResponse handle_request([[maybe_unused]] const message_2
     res.evseid = evse_id;
 
     if (new_session) {
-        return response_with_code(res, message_20::ResponseCode::OK_NewSessionEstablished);
+        return response_with_code(res, dt::ResponseCode::OK_NewSessionEstablished);
     } else {
-        return response_with_code(res, message_20::ResponseCode::OK_OldSessionJoined);
+        return response_with_code(res, dt::ResponseCode::OK_OldSessionJoined);
     }
 }
 

--- a/src/iso15118/d20/state/session_stop.cpp
+++ b/src/iso15118/d20/state/session_stop.cpp
@@ -8,6 +8,8 @@
 
 namespace iso15118::d20::state {
 
+namespace dt = message_20::datatypes;
+
 message_20::SessionStopResponse handle_request(const message_20::SessionStopRequest& req, const d20::Session& session) {
 
     if (req.ev_termination_code.has_value()) {
@@ -20,17 +22,17 @@ message_20::SessionStopResponse handle_request(const message_20::SessionStopRequ
     message_20::SessionStopResponse res;
 
     if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_UnknownSession);
+        return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
-    if (req.charging_session == message_20::ChargingSession::ServiceRenegotiation &&
+    if (req.charging_session == dt::ChargingSession::ServiceRenegotiation &&
         session.service_renegotiation_supported == false) {
-        return response_with_code(res, message_20::ResponseCode::FAILED_NoServiceRenegotiationSupported);
+        return response_with_code(res, dt::ResponseCode::FAILED_NoServiceRenegotiationSupported);
     }
 
     // Todo(sl): Check req.charging_session
 
-    return response_with_code(res, message_20::ResponseCode::OK);
+    return response_with_code(res, dt::ResponseCode::OK);
 }
 
 void SessionStop::enter() {

--- a/src/iso15118/message/ac_charge_loop.cpp
+++ b/src/iso15118/message/ac_charge_loop.cpp
@@ -11,7 +11,7 @@
 
 namespace iso15118::message_20 {
 
-template <> void convert(const struct iso20_ac_DisplayParametersType& in, DisplayParameters& out) {
+template <> void convert(const struct iso20_ac_DisplayParametersType& in, datatypes::DisplayParameters& out) {
 
     CB2CPP_ASSIGN_IF_USED(in.PresentSOC, out.present_soc);
     CB2CPP_ASSIGN_IF_USED(in.MinimumSOC, out.min_soc);
@@ -28,16 +28,16 @@ template <> void convert(const struct iso20_ac_DisplayParametersType& in, Displa
 }
 
 // Todo(sl): this should go to common.cpp
-template <typename InType> void convert(const InType& in, Scheduled_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Scheduled_CLReqControlMode& out) {
     CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy_request);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy_request);
     CB2CPP_CONVERT_IF_USED(in.EVMinimumEnergyRequest, out.min_energy_request);
 }
 
-template <typename InType> void convert(const InType& in, AC_ChargeLoopRequest::Scheduled_AC_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Scheduled_AC_CLReqControlMode& out) {
     static_assert(std::is_same_v<InType, iso20_ac_Scheduled_AC_CLReqControlModeType> or
                   std::is_same_v<InType, iso20_ac_BPT_Scheduled_AC_CLReqControlModeType>);
-    convert(in, static_cast<Scheduled_CLReqControlMode&>(out));
+    convert(in, static_cast<datatypes::Scheduled_CLReqControlMode&>(out));
 
     CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower, out.max_charge_power);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
@@ -58,8 +58,8 @@ template <typename InType> void convert(const InType& in, AC_ChargeLoopRequest::
 
 template <>
 void convert(const struct iso20_ac_BPT_Scheduled_AC_CLReqControlModeType& in,
-             AC_ChargeLoopRequest::BPT_Scheduled_AC_CLReqControlMode& out) {
-    convert(in, static_cast<AC_ChargeLoopRequest::Scheduled_AC_CLReqControlMode&>(out));
+             datatypes::BPT_Scheduled_AC_CLReqControlMode& out) {
+    convert(in, static_cast<datatypes::Scheduled_AC_CLReqControlMode&>(out));
 
     CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower, out.max_discharge_power);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.max_discharge_power_L2);
@@ -71,17 +71,17 @@ void convert(const struct iso20_ac_BPT_Scheduled_AC_CLReqControlModeType& in,
 }
 
 // Todo(sl): this should go to common.cpp
-template <typename InType> void convert(const InType& in, Dynamic_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Dynamic_CLReqControlMode& out) {
     CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
     convert(in.EVTargetEnergyRequest, out.target_energy_request);
     convert(in.EVMaximumEnergyRequest, out.max_energy_request);
     convert(in.EVMinimumEnergyRequest, out.min_energy_request);
 }
 
-template <typename InType> void convert(const InType& in, AC_ChargeLoopRequest::Dynamic_AC_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Dynamic_AC_CLReqControlMode& out) {
     static_assert(std::is_same_v<InType, iso20_ac_Dynamic_AC_CLReqControlModeType> or
                   std::is_same_v<InType, iso20_ac_BPT_Dynamic_AC_CLReqControlModeType>);
-    convert(in, static_cast<Dynamic_CLReqControlMode&>(out));
+    convert(in, static_cast<datatypes::Dynamic_CLReqControlMode&>(out));
 
     convert(in.EVMaximumChargePower, out.max_charge_power);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
@@ -102,8 +102,8 @@ template <typename InType> void convert(const InType& in, AC_ChargeLoopRequest::
 
 template <>
 void convert(const struct iso20_ac_BPT_Dynamic_AC_CLReqControlModeType& in,
-             AC_ChargeLoopRequest::BPT_Dynamic_AC_CLReqControlMode& out) {
-    convert(in, static_cast<AC_ChargeLoopRequest::Dynamic_AC_CLReqControlMode&>(out));
+             datatypes::BPT_Dynamic_AC_CLReqControlMode& out) {
+    convert(in, static_cast<datatypes::Dynamic_AC_CLReqControlMode&>(out));
 
     convert(in.EVMaximumDischargePower, out.max_discharge_power);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.max_discharge_power_L2);
@@ -125,17 +125,15 @@ template <> void convert(const struct iso20_ac_AC_ChargeLoopReqType& in, AC_Char
     out.meter_info_requested = in.MeterInfoRequested;
 
     if (in.Scheduled_AC_CLReqControlMode_isUsed) {
-        convert(in.Scheduled_AC_CLReqControlMode,
-                out.control_mode.emplace<AC_ChargeLoopRequest::Scheduled_AC_CLReqControlMode>());
+        convert(in.Scheduled_AC_CLReqControlMode, out.control_mode.emplace<datatypes::Scheduled_AC_CLReqControlMode>());
     } else if (in.BPT_Scheduled_AC_CLReqControlMode_isUsed) {
         convert(in.BPT_Scheduled_AC_CLReqControlMode,
-                out.control_mode.emplace<AC_ChargeLoopRequest::BPT_Scheduled_AC_CLReqControlMode>());
+                out.control_mode.emplace<datatypes::BPT_Scheduled_AC_CLReqControlMode>());
     } else if (in.Dynamic_AC_CLReqControlMode_isUsed) {
-        convert(in.Dynamic_AC_CLReqControlMode,
-                out.control_mode.emplace<AC_ChargeLoopRequest::Dynamic_AC_CLReqControlMode>());
+        convert(in.Dynamic_AC_CLReqControlMode, out.control_mode.emplace<datatypes::Dynamic_AC_CLReqControlMode>());
     } else if (in.BPT_Dynamic_AC_CLReqControlMode_isUsed) {
         convert(in.BPT_Dynamic_AC_CLReqControlMode,
-                out.control_mode.emplace<AC_ChargeLoopRequest::BPT_Dynamic_AC_CLReqControlMode>());
+                out.control_mode.emplace<datatypes::BPT_Dynamic_AC_CLReqControlMode>());
     } else {
         // should not happen
         assert(false);
@@ -146,19 +144,19 @@ template <> void insert_type(VariantAccess& va, const struct iso20_ac_AC_ChargeL
     va.insert_type<AC_ChargeLoopRequest>(in);
 }
 
-template <> void convert(const DetailedCost& in, struct iso20_ac_DetailedCostType& out) {
+template <> void convert(const datatypes::DetailedCost& in, struct iso20_ac_DetailedCostType& out) {
     init_iso20_ac_DetailedCostType(&out);
     convert(in.amount, out.Amount);
     convert(in.cost_per_unit, out.CostPerUnit);
 }
 
-template <> void convert(const DetailedTax& in, struct iso20_ac_DetailedTaxType& out) {
+template <> void convert(const datatypes::DetailedTax& in, struct iso20_ac_DetailedTaxType& out) {
     init_iso20_ac_DetailedTaxType(&out);
     out.TaxRuleID = in.tax_rule_id;
     convert(in.amount, out.Amount);
 }
 
-template <> void convert(const Receipt& in, struct iso20_ac_ReceiptType& out) {
+template <> void convert(const datatypes::Receipt& in, struct iso20_ac_ReceiptType& out) {
     init_iso20_ac_ReceiptType(&out);
 
     out.TimeAnchor = in.time_anchor;
@@ -176,7 +174,7 @@ template <> void convert(const Receipt& in, struct iso20_ac_ReceiptType& out) {
     out.TaxCosts.arrayLen = in.tax_costs.size();
 }
 
-template <typename cb_Type> void convert(const AC_ChargeLoopResponse::Scheduled_AC_CLResControlMode& in, cb_Type& out) {
+template <typename cb_Type> void convert(const datatypes::Scheduled_AC_CLResControlMode& in, cb_Type& out) {
     CPP2CB_CONVERT_IF_USED(in.target_active_power, out.EVSETargetActivePower);
     CPP2CB_CONVERT_IF_USED(in.target_active_power_L2, out.EVSETargetActivePower_L2);
     CPP2CB_CONVERT_IF_USED(in.target_active_power_L2, out.EVSETargetActivePower_L3);
@@ -191,20 +189,20 @@ template <typename cb_Type> void convert(const AC_ChargeLoopResponse::Scheduled_
 }
 
 template <>
-void convert(const AC_ChargeLoopResponse::BPT_Scheduled_AC_CLResControlMode& in,
+void convert(const datatypes::BPT_Scheduled_AC_CLResControlMode& in,
              struct iso20_ac_BPT_Scheduled_AC_CLResControlModeType& out) {
-    convert(static_cast<const AC_ChargeLoopResponse::Scheduled_AC_CLResControlMode&>(in), out);
+    convert(static_cast<const datatypes::Scheduled_AC_CLResControlMode&>(in), out);
 }
 
-template <typename cb_Type> void convert(const Dynamic_CLResControlMode& in, cb_Type& out) {
+template <typename cb_Type> void convert(const datatypes::Dynamic_CLResControlMode& in, cb_Type& out) {
     CPP2CB_ASSIGN_IF_USED(in.departure_time, out.DepartureTime);
     CPP2CB_ASSIGN_IF_USED(in.minimum_soc, out.MinimumSOC);
     CPP2CB_ASSIGN_IF_USED(in.target_soc, out.TargetSOC);
     CPP2CB_ASSIGN_IF_USED(in.ack_max_delay, out.AckMaxDelay);
 }
 
-template <typename cb_Type> void convert(const AC_ChargeLoopResponse::Dynamic_AC_CLResControlMode& in, cb_Type& out) {
-    convert(static_cast<const Dynamic_CLResControlMode&>(in), out);
+template <typename cb_Type> void convert(const datatypes::Dynamic_AC_CLResControlMode& in, cb_Type& out) {
+    convert(static_cast<const datatypes::Dynamic_CLResControlMode&>(in), out);
 
     convert(in.target_active_power, out.EVSETargetActivePower);
     CPP2CB_CONVERT_IF_USED(in.target_active_power_L2, out.EVSETargetActivePower_L2);
@@ -220,16 +218,16 @@ template <typename cb_Type> void convert(const AC_ChargeLoopResponse::Dynamic_AC
 }
 
 template <>
-void convert(const AC_ChargeLoopResponse::BPT_Dynamic_AC_CLResControlMode& in,
+void convert(const datatypes::BPT_Dynamic_AC_CLResControlMode& in,
              struct iso20_ac_BPT_Dynamic_AC_CLResControlModeType& out) {
-    convert(static_cast<const AC_ChargeLoopResponse::Dynamic_AC_CLResControlMode&>(in), out);
+    convert(static_cast<const datatypes::Dynamic_AC_CLResControlMode&>(in), out);
 }
 
 struct ControlModeVisitor {
-    using ScheduledCM = AC_ChargeLoopResponse::Scheduled_AC_CLResControlMode;
-    using BPT_ScheduledCM = AC_ChargeLoopResponse::BPT_Scheduled_AC_CLResControlMode;
-    using DynamicCM = AC_ChargeLoopResponse::Dynamic_AC_CLResControlMode;
-    using BPT_DynamicCM = AC_ChargeLoopResponse::BPT_Dynamic_AC_CLResControlMode;
+    using ScheduledCM = datatypes::Scheduled_AC_CLResControlMode;
+    using BPT_ScheduledCM = datatypes::BPT_Scheduled_AC_CLResControlMode;
+    using DynamicCM = datatypes::Dynamic_AC_CLResControlMode;
+    using BPT_DynamicCM = datatypes::BPT_Dynamic_AC_CLResControlMode;
 
     ControlModeVisitor(iso20_ac_AC_ChargeLoopResType& res_) : res(res_){};
 

--- a/src/iso15118/message/ac_charge_parameter_discovery.cpp
+++ b/src/iso15118/message/ac_charge_parameter_discovery.cpp
@@ -11,11 +11,11 @@
 
 namespace iso15118::message_20 {
 
-using AC_ModeReq = AC_ChargeParameterDiscoveryRequest::AC_CPDReqEnergyTransferMode;
-using BPT_AC_ModeReq = AC_ChargeParameterDiscoveryRequest::BPT_AC_CPDReqEnergyTransferMode;
+using AC_ModeReq = datatypes::AC_CPDReqEnergyTransferMode;
+using BPT_AC_ModeReq = datatypes::BPT_AC_CPDReqEnergyTransferMode;
 
-using AC_ModeRes = AC_ChargeParameterDiscoveryResponse::AC_CPDResEnergyTransferMode;
-using BPT_AC_ModeRes = AC_ChargeParameterDiscoveryResponse::BPT_AC_CPDResEnergyTransferMode;
+using AC_ModeRes = datatypes::AC_CPDResEnergyTransferMode;
+using BPT_AC_ModeRes = datatypes::BPT_AC_CPDResEnergyTransferMode;
 
 template <> void convert(const struct iso20_ac_AC_CPDReqEnergyTransferModeType& in, AC_ModeReq& out) {
     convert(in.EVMaximumChargePower, out.max_charge_power);

--- a/src/iso15118/message/authorization.cpp
+++ b/src/iso15118/message/authorization.cpp
@@ -13,18 +13,15 @@ namespace iso15118::message_20 {
 template <> void convert(const struct iso20_AuthorizationReqType& in, AuthorizationRequest& out) {
     convert(in.Header, out.header);
 
-    out.selected_authorization_service = static_cast<Authorization>(in.SelectedAuthorizationService);
+    out.selected_authorization_service = static_cast<datatypes::Authorization>(in.SelectedAuthorizationService);
     if (in.EIM_AReqAuthorizationMode_isUsed) {
-        out.eim_as_req_authorization_mode.emplace();
+        out.authorization_mode.emplace<datatypes::EIM_ASReqAuthorizationMode>();
     } else if (in.PnC_AReqAuthorizationMode_isUsed) {
 
-        auto& pnc_out = out.pnc_as_req_authorization_mode.emplace();
+        auto& pnc_out = out.authorization_mode.emplace<datatypes::PnC_ASReqAuthorizationMode>();
 
         pnc_out.id = CB2CPP_STRING(in.PnC_AReqAuthorizationMode.Id);
-        pnc_out.gen_challenge.reserve(in.PnC_AReqAuthorizationMode.GenChallenge.bytesLen);
-        pnc_out.gen_challenge.insert(
-            pnc_out.gen_challenge.end(), &in.PnC_AReqAuthorizationMode.GenChallenge.bytes[0],
-            &in.PnC_AReqAuthorizationMode.GenChallenge.bytes[in.PnC_AReqAuthorizationMode.GenChallenge.bytesLen]);
+        CB2CPP_BYTES(in.PnC_AReqAuthorizationMode.GenChallenge, pnc_out.gen_challenge);
         // Todo(sl): Adding certificate
     }
 }

--- a/src/iso15118/message/authorization_setup.cpp
+++ b/src/iso15118/message/authorization_setup.cpp
@@ -16,11 +16,11 @@ template <> void convert(const struct iso20_AuthorizationSetupReqType& in, Autho
 
 struct AuthorizationModeVisitor {
     AuthorizationModeVisitor(iso20_AuthorizationSetupResType& out_) : out(out_){};
-    void operator()([[maybe_unused]] const AuthorizationSetupResponse::EIM_ASResAuthorizationMode& in) {
+    void operator()([[maybe_unused]] const datatypes::EIM_ASResAuthorizationMode& in) {
         CB_SET_USED(out.EIM_ASResAuthorizationMode);
         init_iso20_EIM_ASResAuthorizationModeType(&out.EIM_ASResAuthorizationMode);
     }
-    void operator()(const AuthorizationSetupResponse::PnC_ASResAuthorizationMode& in) {
+    void operator()(const datatypes::PnC_ASResAuthorizationMode& in) {
         CB_SET_USED(out.PnC_ASResAuthorizationMode);
         init_iso20_PnC_ASResAuthorizationModeType(&out.PnC_ASResAuthorizationMode);
         CPP2CB_BYTES(in.gen_challenge, out.PnC_ASResAuthorizationMode.GenChallenge);

--- a/src/iso15118/message/common_types.cpp
+++ b/src/iso15118/message/common_types.cpp
@@ -2,7 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <cmath>
 
-#include <iso15118/message/common.hpp>
+#include <iso15118/message/common_types.hpp>
 
 #include <iso15118/detail/cb_exi.hpp>
 #include <iso15118/message/variant.hpp>
@@ -48,35 +48,37 @@ template <> void convert(const Header& in, iso20_ac_MessageHeaderType& out) {
     convert_header(in, out);
 }
 
-template <typename cb_RationalNumberType> void convert(const cb_RationalNumberType& in, RationalNumber& out) {
+template <typename cb_RationalNumberType>
+void convert(const cb_RationalNumberType& in, datatypes::RationalNumber& out) {
     out.exponent = in.Exponent;
     out.value = in.Value;
 }
 
-template void convert(const struct iso20_ac_RationalNumberType& in, RationalNumber& out);
-template void convert(const struct iso20_dc_RationalNumberType& in, RationalNumber& out);
-template void convert(const struct iso20_RationalNumberType& in, RationalNumber& out);
+template void convert(const struct iso20_ac_RationalNumberType& in, datatypes::RationalNumber& out);
+template void convert(const struct iso20_dc_RationalNumberType& in, datatypes::RationalNumber& out);
+template void convert(const struct iso20_RationalNumberType& in, datatypes::RationalNumber& out);
 
-template <typename cb_RationalNumberType> void convert(const RationalNumber& in, cb_RationalNumberType& out) {
+template <typename cb_RationalNumberType>
+void convert(const datatypes::RationalNumber& in, cb_RationalNumberType& out) {
     out.Exponent = in.exponent;
     out.Value = in.value;
 }
 
-template void convert(const RationalNumber& in, struct iso20_ac_RationalNumberType& out);
-template void convert(const RationalNumber& in, struct iso20_dc_RationalNumberType& out);
-template void convert(const RationalNumber& in, struct iso20_RationalNumberType& out);
+template void convert(const datatypes::RationalNumber& in, struct iso20_ac_RationalNumberType& out);
+template void convert(const datatypes::RationalNumber& in, struct iso20_dc_RationalNumberType& out);
+template void convert(const datatypes::RationalNumber& in, struct iso20_RationalNumberType& out);
 
-template <> void convert(const EvseStatus& in, struct iso20_dc_EVSEStatusType& out) {
+template <> void convert(const datatypes::EvseStatus& in, struct iso20_dc_EVSEStatusType& out) {
     out.NotificationMaxDelay = in.notification_max_delay;
     cb_convert_enum(in.notification, out.EVSENotification);
 }
 
-template <> void convert(const EvseStatus& in, struct iso20_ac_EVSEStatusType& out) {
+template <> void convert(const datatypes::EvseStatus& in, struct iso20_ac_EVSEStatusType& out) {
     out.NotificationMaxDelay = in.notification_max_delay;
     cb_convert_enum(in.notification, out.EVSENotification);
 }
 
-template <typename cb_MeterInfoType> void convert_meterinfo(const MeterInfo& in, cb_MeterInfoType& out) {
+template <typename cb_MeterInfoType> void convert_meterinfo(const datatypes::MeterInfo& in, cb_MeterInfoType& out) {
 
     CPP2CB_STRING(in.meter_id, out.MeterID);
     out.ChargedEnergyReadingWh = in.charged_energy_reading_wh;
@@ -94,20 +96,22 @@ template <typename cb_MeterInfoType> void convert_meterinfo(const MeterInfo& in,
     CPP2CB_ASSIGN_IF_USED(in.meter_timestamp, out.MeterTimestamp);
 }
 
-template <> void convert(const MeterInfo& in, iso20_dc_MeterInfoType& out) {
+template <> void convert(const datatypes::MeterInfo& in, iso20_dc_MeterInfoType& out) {
     init_iso20_dc_MeterInfoType(&out);
     convert_meterinfo(in, out);
 }
 
-template <> void convert(const MeterInfo& in, iso20_ac_MeterInfoType& out) {
+template <> void convert(const datatypes::MeterInfo& in, iso20_ac_MeterInfoType& out) {
     init_iso20_ac_MeterInfoType(&out);
     convert_meterinfo(in, out);
 }
 
-template <> void convert(const EvseStatus& in, iso20_EVSEStatusType& out) {
+template <> void convert(const datatypes::EvseStatus& in, iso20_EVSEStatusType& out) {
     out.NotificationMaxDelay = in.notification_max_delay;
     cb_convert_enum(in.notification, out.EVSENotification);
 }
+
+namespace datatypes {
 
 float from_RationalNumber(const RationalNumber& in) {
     return in.value * pow(10, in.exponent);
@@ -158,5 +162,7 @@ std::string from_mobility_needs_mode(const MobilityNeedsMode& in) {
     }
     return "";
 }
+
+} // namespace datatypes
 
 } // namespace iso15118::message_20

--- a/src/iso15118/message/dc_charge_loop.cpp
+++ b/src/iso15118/message/dc_charge_loop.cpp
@@ -11,7 +11,7 @@
 
 namespace iso15118::message_20 {
 
-template <> void convert(const struct iso20_dc_DisplayParametersType& in, DisplayParameters& out) {
+template <> void convert(const struct iso20_dc_DisplayParametersType& in, datatypes::DisplayParameters& out) {
     CB2CPP_ASSIGN_IF_USED(in.PresentSOC, out.present_soc);
     CB2CPP_ASSIGN_IF_USED(in.MinimumSOC, out.min_soc);
     CB2CPP_ASSIGN_IF_USED(in.TargetSOC, out.target_soc);
@@ -27,16 +27,16 @@ template <> void convert(const struct iso20_dc_DisplayParametersType& in, Displa
 }
 
 // FIXME (aw): this should go to common.cpp
-template <typename InType> void convert(const InType& in, Scheduled_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Scheduled_CLReqControlMode& out) {
     CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy_request);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy_request);
     CB2CPP_CONVERT_IF_USED(in.EVMinimumEnergyRequest, out.min_energy_request);
 }
 
-template <typename InType> void convert(const InType& in, DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Scheduled_DC_CLReqControlMode& out) {
     static_assert(std::is_same_v<InType, iso20_dc_Scheduled_DC_CLReqControlModeType> or
                   std::is_same_v<InType, iso20_dc_BPT_Scheduled_DC_CLReqControlModeType>);
-    convert(in, static_cast<Scheduled_CLReqControlMode&>(out));
+    convert(in, static_cast<datatypes::Scheduled_CLReqControlMode&>(out));
 
     convert(in.EVTargetCurrent, out.target_current);
     convert(in.EVTargetVoltage, out.target_voltage);
@@ -50,8 +50,8 @@ template <typename InType> void convert(const InType& in, DC_ChargeLoopRequest::
 
 template <>
 void convert(const struct iso20_dc_BPT_Scheduled_DC_CLReqControlModeType& in,
-             DC_ChargeLoopRequest::BPT_Scheduled_DC_CLReqControlMode& out) {
-    convert(in, static_cast<DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode&>(out));
+             datatypes::BPT_Scheduled_DC_CLReqControlMode& out) {
+    convert(in, static_cast<datatypes::Scheduled_DC_CLReqControlMode&>(out));
 
     CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower, out.max_discharge_power);
     CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower, out.min_discharge_power);
@@ -59,17 +59,17 @@ void convert(const struct iso20_dc_BPT_Scheduled_DC_CLReqControlModeType& in,
 }
 
 // FIXME (aw): this should go to common.cpp
-template <typename InType> void convert(const InType& in, Dynamic_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Dynamic_CLReqControlMode& out) {
     CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
     convert(in.EVTargetEnergyRequest, out.target_energy_request);
     convert(in.EVMaximumEnergyRequest, out.max_energy_request);
     convert(in.EVMinimumEnergyRequest, out.min_energy_request);
 }
 
-template <typename InType> void convert(const InType& in, DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode& out) {
+template <typename InType> void convert(const InType& in, datatypes::Dynamic_DC_CLReqControlMode& out) {
     static_assert(std::is_same_v<InType, iso20_dc_Dynamic_DC_CLReqControlModeType> or
                   std::is_same_v<InType, iso20_dc_BPT_Dynamic_DC_CLReqControlModeType>);
-    convert(in, static_cast<Dynamic_CLReqControlMode&>(out));
+    convert(in, static_cast<datatypes::Dynamic_CLReqControlMode&>(out));
 
     convert(in.EVMaximumChargePower, out.max_charge_power);
     convert(in.EVMinimumChargePower, out.min_charge_power);
@@ -80,8 +80,8 @@ template <typename InType> void convert(const InType& in, DC_ChargeLoopRequest::
 
 template <>
 void convert(const struct iso20_dc_BPT_Dynamic_DC_CLReqControlModeType& in,
-             DC_ChargeLoopRequest::BPT_Dynamic_DC_CLReqControlMode& out) {
-    convert(in, static_cast<DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode&>(out));
+             datatypes::BPT_Dynamic_DC_CLReqControlMode& out) {
+    convert(in, static_cast<datatypes::Dynamic_DC_CLReqControlMode&>(out));
 
     convert(in.EVMaximumDischargePower, out.max_discharge_power);
     convert(in.EVMinimumDischargePower, out.min_discharge_power);
@@ -100,17 +100,15 @@ template <> void convert(const struct iso20_dc_DC_ChargeLoopReqType& in, DC_Char
     convert(in.EVPresentVoltage, out.present_voltage);
 
     if (in.Scheduled_DC_CLReqControlMode_isUsed) {
-        convert(in.Scheduled_DC_CLReqControlMode,
-                out.control_mode.emplace<DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode>());
+        convert(in.Scheduled_DC_CLReqControlMode, out.control_mode.emplace<datatypes::Scheduled_DC_CLReqControlMode>());
     } else if (in.BPT_Scheduled_DC_CLReqControlMode_isUsed) {
         convert(in.BPT_Scheduled_DC_CLReqControlMode,
-                out.control_mode.emplace<DC_ChargeLoopRequest::BPT_Scheduled_DC_CLReqControlMode>());
+                out.control_mode.emplace<datatypes::BPT_Scheduled_DC_CLReqControlMode>());
     } else if (in.Dynamic_DC_CLReqControlMode_isUsed) {
-        convert(in.Dynamic_DC_CLReqControlMode,
-                out.control_mode.emplace<DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode>());
+        convert(in.Dynamic_DC_CLReqControlMode, out.control_mode.emplace<datatypes::Dynamic_DC_CLReqControlMode>());
     } else if (in.BPT_Dynamic_DC_CLReqControlMode_isUsed) {
         convert(in.BPT_Dynamic_DC_CLReqControlMode,
-                out.control_mode.emplace<DC_ChargeLoopRequest::BPT_Dynamic_DC_CLReqControlMode>());
+                out.control_mode.emplace<datatypes::BPT_Dynamic_DC_CLReqControlMode>());
     } else {
         // should not happen
         assert(false);
@@ -121,19 +119,19 @@ template <> void insert_type(VariantAccess& va, const struct iso20_dc_DC_ChargeL
     va.insert_type<DC_ChargeLoopRequest>(in);
 }
 
-template <> void convert(const DetailedCost& in, struct iso20_dc_DetailedCostType& out) {
+template <> void convert(const datatypes::DetailedCost& in, struct iso20_dc_DetailedCostType& out) {
     init_iso20_dc_DetailedCostType(&out);
     convert(in.amount, out.Amount);
     convert(in.cost_per_unit, out.CostPerUnit);
 }
 
-template <> void convert(const DetailedTax& in, struct iso20_dc_DetailedTaxType& out) {
+template <> void convert(const datatypes::DetailedTax& in, struct iso20_dc_DetailedTaxType& out) {
     init_iso20_dc_DetailedTaxType(&out);
     out.TaxRuleID = in.tax_rule_id;
     convert(in.amount, out.Amount);
 }
 
-template <> void convert(const Receipt& in, struct iso20_dc_ReceiptType& out) {
+template <> void convert(const datatypes::Receipt& in, struct iso20_dc_ReceiptType& out) {
     init_iso20_dc_ReceiptType(&out);
 
     out.TimeAnchor = in.time_anchor;
@@ -151,14 +149,14 @@ template <> void convert(const Receipt& in, struct iso20_dc_ReceiptType& out) {
     out.TaxCosts.arrayLen = in.tax_costs.size();
 }
 
-template <typename cb_Type> void convert(const DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode& in, cb_Type& out) {
+template <typename cb_Type> void convert(const datatypes::Scheduled_DC_CLResControlMode& in, cb_Type& out) {
     CPP2CB_CONVERT_IF_USED(in.max_charge_power, out.EVSEMaximumChargePower);
     CPP2CB_CONVERT_IF_USED(in.min_charge_power, out.EVSEMinimumChargePower);
     CPP2CB_CONVERT_IF_USED(in.max_charge_current, out.EVSEMaximumChargeCurrent);
     CPP2CB_CONVERT_IF_USED(in.max_voltage, out.EVSEMaximumVoltage);
 }
 
-template <typename cb_Type> void convert(const Dynamic_CLResControlMode& in, cb_Type& out) {
+template <typename cb_Type> void convert(const datatypes::Dynamic_CLResControlMode& in, cb_Type& out) {
     CPP2CB_ASSIGN_IF_USED(in.departure_time, out.DepartureTime);
     CPP2CB_ASSIGN_IF_USED(in.minimum_soc, out.MinimumSOC);
     CPP2CB_ASSIGN_IF_USED(in.target_soc, out.TargetSOC);
@@ -166,9 +164,9 @@ template <typename cb_Type> void convert(const Dynamic_CLResControlMode& in, cb_
 }
 
 template <>
-void convert(const DC_ChargeLoopResponse::BPT_Scheduled_DC_CLResControlMode& in,
+void convert(const datatypes::BPT_Scheduled_DC_CLResControlMode& in,
              struct iso20_dc_BPT_Scheduled_DC_CLResControlModeType& out) {
-    convert(static_cast<const DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode&>(in), out);
+    convert(static_cast<const datatypes::Scheduled_DC_CLResControlMode&>(in), out);
 
     CPP2CB_CONVERT_IF_USED(in.max_discharge_power, out.EVSEMaximumDischargePower);
     CPP2CB_CONVERT_IF_USED(in.min_discharge_power, out.EVSEMinimumDischargePower);
@@ -176,8 +174,8 @@ void convert(const DC_ChargeLoopResponse::BPT_Scheduled_DC_CLResControlMode& in,
     CPP2CB_CONVERT_IF_USED(in.min_voltage, out.EVSEMinimumVoltage);
 }
 
-template <typename cb_Type> void convert(const DC_ChargeLoopResponse::Dynamic_DC_CLResControlMode& in, cb_Type& out) {
-    convert(static_cast<const Dynamic_CLResControlMode&>(in), out);
+template <typename cb_Type> void convert(const datatypes::Dynamic_DC_CLResControlMode& in, cb_Type& out) {
+    convert(static_cast<const datatypes::Dynamic_CLResControlMode&>(in), out);
 
     convert(in.max_charge_power, out.EVSEMaximumChargePower);
     convert(in.min_charge_power, out.EVSEMinimumChargePower);
@@ -186,9 +184,9 @@ template <typename cb_Type> void convert(const DC_ChargeLoopResponse::Dynamic_DC
 }
 
 template <>
-void convert(const DC_ChargeLoopResponse::BPT_Dynamic_DC_CLResControlMode& in,
+void convert(const datatypes::BPT_Dynamic_DC_CLResControlMode& in,
              struct iso20_dc_BPT_Dynamic_DC_CLResControlModeType& out) {
-    convert(static_cast<const DC_ChargeLoopResponse::Dynamic_DC_CLResControlMode&>(in), out);
+    convert(static_cast<const datatypes::Dynamic_DC_CLResControlMode&>(in), out);
 
     convert(in.max_discharge_power, out.EVSEMaximumDischargePower);
     convert(in.min_discharge_power, out.EVSEMinimumDischargePower);
@@ -197,10 +195,10 @@ void convert(const DC_ChargeLoopResponse::BPT_Dynamic_DC_CLResControlMode& in,
 }
 
 struct ControlModeVisitor {
-    using ScheduledCM = DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode;
-    using BPT_ScheduledCM = DC_ChargeLoopResponse::BPT_Scheduled_DC_CLResControlMode;
-    using DynamicCM = DC_ChargeLoopResponse::Dynamic_DC_CLResControlMode;
-    using BPT_DynamicCM = DC_ChargeLoopResponse::BPT_Dynamic_DC_CLResControlMode;
+    using ScheduledCM = datatypes::Scheduled_DC_CLResControlMode;
+    using BPT_ScheduledCM = datatypes::BPT_Scheduled_DC_CLResControlMode;
+    using DynamicCM = datatypes::Dynamic_DC_CLResControlMode;
+    using BPT_DynamicCM = datatypes::BPT_Dynamic_DC_CLResControlMode;
 
     ControlModeVisitor(iso20_dc_DC_ChargeLoopResType& res_) : res(res_){};
     void operator()(const ScheduledCM& in) {

--- a/src/iso15118/message/dc_charge_parameter_discovery.cpp
+++ b/src/iso15118/message/dc_charge_parameter_discovery.cpp
@@ -11,11 +11,11 @@
 
 namespace iso15118::message_20 {
 
-using DC_ModeReq = DC_ChargeParameterDiscoveryRequest::DC_CPDReqEnergyTransferMode;
-using BPT_DC_ModeReq = DC_ChargeParameterDiscoveryRequest::BPT_DC_CPDReqEnergyTransferMode;
+using DC_ModeReq = datatypes::DC_CPDReqEnergyTransferMode;
+using BPT_DC_ModeReq = datatypes::BPT_DC_CPDReqEnergyTransferMode;
 
-using DC_ModeRes = DC_ChargeParameterDiscoveryResponse::DC_CPDResEnergyTransferMode;
-using BPT_DC_ModeRes = DC_ChargeParameterDiscoveryResponse::BPT_DC_CPDResEnergyTransferMode;
+using DC_ModeRes = datatypes::DC_CPDResEnergyTransferMode;
+using BPT_DC_ModeRes = datatypes::BPT_DC_CPDResEnergyTransferMode;
 
 template <> void convert(const struct iso20_dc_DC_CPDReqEnergyTransferModeType& in, DC_ModeReq& out) {
     convert(in.EVMaximumChargePower, out.max_charge_power);

--- a/src/iso15118/message/power_delivery.cpp
+++ b/src/iso15118/message/power_delivery.cpp
@@ -11,30 +11,28 @@
 namespace iso15118::message_20 {
 
 template <>
-void convert(const struct iso20_Scheduled_EVPPTControlModeType& in,
-             PowerDeliveryRequest::Scheduled_EVPPTControlMode& out) {
+void convert(const struct iso20_Scheduled_EVPPTControlModeType& in, datatypes::Scheduled_EVPPTControlMode& out) {
     if (in.PowerToleranceAcceptance_isUsed) {
-        out.power_tolerance_acceptance =
-            static_cast<message_20::PowerDeliveryRequest::PowerToleranceAcceptance>(in.PowerToleranceAcceptance);
+        out.power_tolerance_acceptance = static_cast<datatypes::PowerToleranceAcceptance>(in.PowerToleranceAcceptance);
     }
     out.selected_schedule = in.SelectedScheduleTupleID;
 }
 
-template <> void convert(const struct iso20_PowerScheduleEntryType& in, PowerDeliveryRequest::PowerScheduleEntry& out) {
+template <> void convert(const struct iso20_PowerScheduleEntryType& in, datatypes::PowerScheduleEntry& out) {
     out.duration = in.Duration;
     convert(in.Power, out.power);
     CB2CPP_CONVERT_IF_USED(in.Power_L2, out.power_l2);
     CB2CPP_CONVERT_IF_USED(in.Power_L3, out.power_l3);
 }
 
-template <> void convert(const struct iso20_EVPowerProfileType& in, PowerDeliveryRequest::PowerProfile& out) {
+template <> void convert(const struct iso20_EVPowerProfileType& in, datatypes::PowerProfile& out) {
     out.time_anchor = in.TimeAnchor;
 
     if (in.Dynamic_EVPPTControlMode_isUsed) {
-        out.control_mode.emplace<PowerDeliveryRequest::Dynamic_EVPPTControlMode>();
+        out.control_mode.emplace<datatypes::Dynamic_EVPPTControlMode>();
         // NOTE (aw): nothing more to do here because Dynamic_EVPPTControlMode is empty
     } else if (in.Scheduled_EVPPTControlMode_isUsed) {
-        auto& cm = out.control_mode.emplace<PowerDeliveryRequest::Scheduled_EVPPTControlMode>();
+        auto& cm = out.control_mode.emplace<datatypes::Scheduled_EVPPTControlMode>();
         convert(in.Scheduled_EVPPTControlMode, cm);
     } else {
         throw std::runtime_error("PowerProfile control mode not defined");
@@ -49,7 +47,7 @@ template <> void convert(const struct iso20_EVPowerProfileType& in, PowerDeliver
     }
 }
 
-void convert(const iso20_channelSelectionType in, PowerDeliveryRequest::ChannelSelection& out) {
+void convert(const iso20_channelSelectionType in, datatypes::ChannelSelection& out) {
     cb_convert_enum(in, out);
 }
 

--- a/src/iso15118/message/schedule_exchange.cpp
+++ b/src/iso15118/message/schedule_exchange.cpp
@@ -12,13 +12,12 @@
 
 namespace iso15118::message_20 {
 
-template <>
-void convert(const struct iso20_EVPowerScheduleEntryType& in, ScheduleExchangeRequest::EVPowerScheduleEntry& out) {
+template <> void convert(const struct iso20_EVPowerScheduleEntryType& in, datatypes::EVPowerScheduleEntry& out) {
     out.duration = in.Duration;
     convert(in.Power, out.power);
 }
 
-template <> void convert(const struct iso20_EVPowerScheduleType& in, ScheduleExchangeRequest::EVPowerSchedule& out) {
+template <> void convert(const struct iso20_EVPowerScheduleType& in, datatypes::EVPowerSchedule& out) {
     out.time_anchor = in.TimeAnchor;
     const auto& entries_in = in.EVPowerScheduleEntries.EVPowerScheduleEntry;
     out.entries.reserve(entries_in.arrayLen);
@@ -29,12 +28,12 @@ template <> void convert(const struct iso20_EVPowerScheduleType& in, ScheduleExc
     }
 }
 
-template <> void convert(const struct iso20_EVPriceRuleType& in, ScheduleExchangeRequest::EVPriceRule& out) {
+template <> void convert(const struct iso20_EVPriceRuleType& in, datatypes::EVPriceRule& out) {
     convert(in.EnergyFee, out.energy_fee);
     convert(in.PowerRangeStart, out.power_range_start);
 }
 
-template <> void convert(const struct iso20_EVPriceRuleStackType& in, ScheduleExchangeRequest::EVPriceRuleStack& out) {
+template <> void convert(const struct iso20_EVPriceRuleStackType& in, datatypes::EVPriceRuleStack& out) {
     out.duration = in.Duration;
 
     const auto& rules_in = in.EVPriceRule;
@@ -46,9 +45,7 @@ template <> void convert(const struct iso20_EVPriceRuleStackType& in, ScheduleEx
     }
 }
 
-template <>
-void convert(const struct iso20_EVAbsolutePriceScheduleType& in,
-             ScheduleExchangeRequest::EVAbsolutePriceSchedule& out) {
+template <> void convert(const struct iso20_EVAbsolutePriceScheduleType& in, datatypes::EVAbsolutePriceSchedule& out) {
     out.time_anchor = in.TimeAnchor;
     out.currency = CB2CPP_STRING(in.Currency);
     out.price_algorithm = CB2CPP_STRING(in.PriceAlgorithm);
@@ -62,14 +59,13 @@ void convert(const struct iso20_EVAbsolutePriceScheduleType& in,
     }
 }
 
-template <> void convert(const struct iso20_EVEnergyOfferType& in, ScheduleExchangeRequest::EVEnergyOffer& out) {
+template <> void convert(const struct iso20_EVEnergyOfferType& in, datatypes::EVEnergyOffer& out) {
     convert(in.EVPowerSchedule, out.power_schedule);
     convert(in.EVAbsolutePriceSchedule, out.absolute_price_schedule);
 }
 
 template <>
-void convert(const struct iso20_Scheduled_SEReqControlModeType& in,
-             ScheduleExchangeRequest::Scheduled_SEReqControlMode& out) {
+void convert(const struct iso20_Scheduled_SEReqControlModeType& in, datatypes::Scheduled_SEReqControlMode& out) {
     CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
     CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy);
@@ -78,8 +74,7 @@ void convert(const struct iso20_Scheduled_SEReqControlModeType& in,
 }
 
 template <>
-void convert(const struct iso20_Dynamic_SEReqControlModeType& in,
-             ScheduleExchangeRequest::Dynamic_SEReqControlMode& out) {
+void convert(const struct iso20_Dynamic_SEReqControlModeType& in, datatypes::Dynamic_SEReqControlMode& out) {
     out.departure_time = in.DepartureTime;
     CB2CPP_ASSIGN_IF_USED(in.MinimumSOC, out.minimum_soc);
     CB2CPP_ASSIGN_IF_USED(in.TargetSOC, out.target_soc);
@@ -96,17 +91,17 @@ template <> void convert(const struct iso20_ScheduleExchangeReqType& in, Schedul
     out.max_supporting_points = in.MaximumSupportingPoints;
 
     if (in.Dynamic_SEReqControlMode_isUsed) {
-        auto& mode_out = out.control_mode.emplace<ScheduleExchangeRequest::Dynamic_SEReqControlMode>();
+        auto& mode_out = out.control_mode.emplace<datatypes::Dynamic_SEReqControlMode>();
         convert(in.Dynamic_SEReqControlMode, mode_out);
     } else if (in.Scheduled_SEReqControlMode_isUsed) {
-        auto& mode_out = out.control_mode.emplace<ScheduleExchangeRequest::Scheduled_SEReqControlMode>();
+        auto& mode_out = out.control_mode.emplace<datatypes::Scheduled_SEReqControlMode>();
         convert(in.Scheduled_SEReqControlMode, mode_out);
     } else {
         throw std::runtime_error("No control mode selected in iso20_ScheduleExchangeReqType");
     }
 }
 
-template <> void convert(const ScheduleExchangeResponse::PowerSchedule& in, struct iso20_PowerScheduleType& out) {
+template <> void convert(const datatypes::PowerSchedule& in, struct iso20_PowerScheduleType& out) {
     init_iso20_PowerScheduleType(&out);
 
     out.TimeAnchor = in.time_anchor;
@@ -130,7 +125,7 @@ template <> void convert(const ScheduleExchangeResponse::PowerSchedule& in, stru
     out.PowerScheduleEntries.PowerScheduleEntry.arrayLen = in.entries.size();
 }
 
-template <> void convert(const ScheduleExchangeResponse::TaxRule& in, struct iso20_TaxRuleType& out) {
+template <> void convert(const datatypes::TaxRule& in, struct iso20_TaxRuleType& out) {
     out.TaxRuleID = in.tax_rule_id;
     CPP2CB_STRING_IF_USED(in.tax_rule_name, out.TaxRuleName);
     convert(in.tax_rate, out.TaxRate);
@@ -141,7 +136,7 @@ template <> void convert(const ScheduleExchangeResponse::TaxRule& in, struct iso
     out.AppliesMinimumMaximumCost = in.applies_to_minimum_maximum_cost;
 }
 
-template <> void convert(const ScheduleExchangeResponse::PriceRule& in, struct iso20_PriceRuleType& out) {
+template <> void convert(const datatypes::PriceRule& in, struct iso20_PriceRuleType& out) {
     convert(in.energy_fee, out.EnergyFee);
     CPP2CB_CONVERT_IF_USED(in.parking_fee, out.ParkingFee);
     CPP2CB_ASSIGN_IF_USED(in.parking_fee_period, out.ParkingFeePeriod);
@@ -150,7 +145,7 @@ template <> void convert(const ScheduleExchangeResponse::PriceRule& in, struct i
     convert(in.power_range_start, out.PowerRangeStart);
 }
 
-template <> void convert(const ScheduleExchangeResponse::PriceRuleStack& in, struct iso20_PriceRuleStackType& out) {
+template <> void convert(const datatypes::PriceRuleStack& in, struct iso20_PriceRuleStackType& out) {
     out.Duration = in.duration;
 
     if ((sizeof(out.PriceRule.array) / sizeof(out.PriceRule.array[0])) < in.price_rule.size()) {
@@ -162,15 +157,14 @@ template <> void convert(const ScheduleExchangeResponse::PriceRuleStack& in, str
     out.PriceRule.arrayLen = in.price_rule.size();
 }
 
-template <> void convert(const ScheduleExchangeResponse::OverstayRule& in, struct iso20_OverstayRuleType& out) {
+template <> void convert(const datatypes::OverstayRule& in, struct iso20_OverstayRuleType& out) {
     CPP2CB_STRING_IF_USED(in.overstay_rule_description, out.OverstayRuleDescription);
     out.StartTime = in.start_time;
     convert(in.overstay_fee, out.OverstayFee);
     out.OverstayFeePeriod = in.overstay_fee_period;
 }
 
-template <>
-void convert(const ScheduleExchangeResponse::AbsolutePriceSchedule& in, struct iso20_AbsolutePriceScheduleType& out) {
+template <> void convert(const datatypes::AbsolutePriceSchedule& in, struct iso20_AbsolutePriceScheduleType& out) {
 
     CPP2CB_STRING_IF_USED(in.id, out.Id);
     out.TimeAnchor = in.time_anchor;
@@ -242,8 +236,7 @@ void convert(const ScheduleExchangeResponse::AbsolutePriceSchedule& in, struct i
     }
 }
 
-template <>
-void convert(const ScheduleExchangeResponse::PriceLevelSchedule& in, struct iso20_PriceLevelScheduleType& out) {
+template <> void convert(const datatypes::PriceLevelSchedule& in, struct iso20_PriceLevelScheduleType& out) {
 
     CPP2CB_STRING_IF_USED(in.id, out.Id);
     out.TimeAnchor = in.time_anchor;
@@ -267,14 +260,13 @@ void convert(const ScheduleExchangeResponse::PriceLevelSchedule& in, struct iso2
     out.PriceLevelScheduleEntries.PriceLevelScheduleEntry.arrayLen = in.price_level_schedule_entries.size();
 }
 
-using PriceSchedule = std::variant<std::monostate, ScheduleExchangeResponse::AbsolutePriceSchedule,
-                                   ScheduleExchangeResponse::PriceLevelSchedule>;
+using PriceSchedule = std::variant<std::monostate, datatypes::AbsolutePriceSchedule, datatypes::PriceLevelSchedule>;
 template <typename CbMessageType> void convert_price_schedule(const PriceSchedule& in, CbMessageType& out) {
 
-    if (const auto* absolute_price = std::get_if<ScheduleExchangeResponse::AbsolutePriceSchedule>(&in)) {
+    if (const auto* absolute_price = std::get_if<datatypes::AbsolutePriceSchedule>(&in)) {
         convert(*absolute_price, out.AbsolutePriceSchedule);
         out.AbsolutePriceSchedule_isUsed = true;
-    } else if (const auto* price_level_schedule = std::get_if<ScheduleExchangeResponse::PriceLevelSchedule>(&in)) {
+    } else if (const auto* price_level_schedule = std::get_if<datatypes::PriceLevelSchedule>(&in)) {
         convert(*price_level_schedule, out.PriceLevelSchedule);
         out.PriceLevelSchedule_isUsed = true;
     } else {
@@ -290,14 +282,14 @@ template <> void convert(const PriceSchedule& in, struct iso20_Dynamic_SEResCont
     convert_price_schedule(in, out);
 }
 
-template <> void convert(const ScheduleExchangeResponse::ChargingSchedule& in, struct iso20_ChargingScheduleType& out) {
+template <> void convert(const datatypes::ChargingSchedule& in, struct iso20_ChargingScheduleType& out) {
     init_iso20_ChargingScheduleType(&out);
 
     convert(in.power_schedule, out.PowerSchedule);
     convert(in.price_schedule, out);
 }
 
-template <> void convert(const ScheduleExchangeResponse::ScheduleTuple& in, struct iso20_ScheduleTupleType& out) {
+template <> void convert(const datatypes::ScheduleTuple& in, struct iso20_ScheduleTupleType& out) {
     init_iso20_ScheduleTupleType(&out);
 
     out.ScheduleTupleID = in.schedule_tuple_id;
@@ -307,7 +299,7 @@ template <> void convert(const ScheduleExchangeResponse::ScheduleTuple& in, stru
 
 struct ModeResponseVisitor {
     ModeResponseVisitor(iso20_ScheduleExchangeResType& res_) : res(res_){};
-    void operator()(const ScheduleExchangeResponse::Dynamic_SEResControlMode& in) {
+    void operator()(const datatypes::Dynamic_SEResControlMode& in) {
         init_iso20_Dynamic_SEResControlModeType(&res.Dynamic_SEResControlMode);
         CB_SET_USED(res.Dynamic_SEResControlMode);
 
@@ -320,7 +312,7 @@ struct ModeResponseVisitor {
         convert(in.price_schedule, out);
     }
 
-    void operator()(const ScheduleExchangeResponse::Scheduled_SEResControlMode& in) {
+    void operator()(const datatypes::Scheduled_SEResControlMode& in) {
         init_iso20_Scheduled_SEResControlModeType(&res.Scheduled_SEResControlMode);
         CB_SET_USED(res.Scheduled_SEResControlMode);
 

--- a/src/iso15118/message/service_detail.cpp
+++ b/src/iso15118/message/service_detail.cpp
@@ -10,9 +10,9 @@
 
 namespace iso15118::message_20 {
 
-// todo(sl): refactor in header file
+namespace datatypes {
 // default
-ServiceDetailResponse::ParameterSet::ParameterSet() {
+ParameterSet::ParameterSet() {
     id = 0;
     parameter.push_back({
         "Connector",                            // name
@@ -32,7 +32,7 @@ ServiceDetailResponse::ParameterSet::ParameterSet() {
     });
 }
 
-ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcParameterList& list) {
+ParameterSet::ParameterSet(uint16_t _id, const DcParameterList& list) {
     id = _id;
     // Connector
     auto& connector = parameter.emplace_back();
@@ -45,8 +45,8 @@ ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcParamete
     // MobilityNeedsMode
     auto& mobility = parameter.emplace_back();
     mobility.name = "MobilityNeedsMode";
-    if (list.control_mode == message_20::ControlMode::Scheduled) {
-        mobility.value = static_cast<int32_t>(message_20::MobilityNeedsMode::ProvidedByEvcc);
+    if (list.control_mode == ControlMode::Scheduled) {
+        mobility.value = static_cast<int32_t>(MobilityNeedsMode::ProvidedByEvcc);
     } else {
         mobility.value = static_cast<int32_t>(list.mobility_needs_mode);
     }
@@ -56,7 +56,7 @@ ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcParamete
     pricing.value = static_cast<int32_t>(list.pricing);
 }
 
-ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcBptParameterList& list) {
+ParameterSet::ParameterSet(uint16_t _id, const DcBptParameterList& list) {
     id = _id;
     // Todo(sl): Refactor because of duplicate code
     // Connector
@@ -70,8 +70,8 @@ ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcBptParam
     // MobilityNeedsMode
     auto& mobility = parameter.emplace_back();
     mobility.name = "MobilityNeedsMode";
-    if (list.control_mode == message_20::ControlMode::Scheduled) {
-        mobility.value = static_cast<int32_t>(message_20::MobilityNeedsMode::ProvidedByEvcc);
+    if (list.control_mode == ControlMode::Scheduled) {
+        mobility.value = static_cast<int32_t>(MobilityNeedsMode::ProvidedByEvcc);
     } else {
         mobility.value = static_cast<int32_t>(list.mobility_needs_mode);
     }
@@ -89,19 +89,19 @@ ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const DcBptParam
     generator_mode.value = static_cast<int32_t>(list.generator_mode);
 }
 
-ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const InternetParameterList& list) {
+ParameterSet::ParameterSet(uint16_t _id, const InternetParameterList& list) {
     id = _id;
 
     auto& protocol = parameter.emplace_back();
     protocol.name = "Protocol";
-    protocol.value = message_20::from_Protocol(list.protocol);
+    protocol.value = from_Protocol(list.protocol);
 
     auto& port = parameter.emplace_back();
     port.name = "Port";
     port.value = static_cast<int32_t>(list.port);
 }
 
-ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const ParkingParameterList& list) {
+ParameterSet::ParameterSet(uint16_t _id, const ParkingParameterList& list) {
     id = _id;
     auto& intended_service = parameter.emplace_back();
     intended_service.name = "IntendedService";
@@ -111,9 +111,11 @@ ServiceDetailResponse::ParameterSet::ParameterSet(uint16_t _id, const ParkingPar
     parking_status.value = static_cast<int32_t>(list.parking_status);
 }
 
+} // namespace datatypes
+
 template <> void convert(const struct iso20_ServiceDetailReqType& in, ServiceDetailRequest& out) {
     convert(in.Header, out.header);
-    out.service = static_cast<ServiceCategory>(in.ServiceID);
+    out.service = static_cast<datatypes::ServiceCategory>(in.ServiceID);
 }
 
 struct ParamterValueVisitor {
@@ -138,7 +140,7 @@ struct ParamterValueVisitor {
         CB_SET_USED(parameter.finiteString);
         CPP2CB_STRING(in, parameter.finiteString);
     }
-    void operator()(const message_20::RationalNumber& in) {
+    void operator()(const message_20::datatypes::RationalNumber& in) {
         CB_SET_USED(parameter.rationalNumber);
         parameter.rationalNumber.Exponent = in.exponent;
         parameter.rationalNumber.Value = in.value;

--- a/src/iso15118/tbd_controller.cpp
+++ b/src/iso15118/tbd_controller.cpp
@@ -62,7 +62,7 @@ void TbdController::send_control_event(const d20::ControlEvent& event) {
     }
 }
 
-void TbdController::update_authorization_services(const std::vector<message_20::Authorization>& services,
+void TbdController::update_authorization_services(const std::vector<message_20::datatypes::Authorization>& services,
                                                   bool cert_install_service) {
 
     evse_setup.enable_certificate_install_service = cert_install_service;

--- a/test/exi/cb/iso20/authorization.cpp
+++ b/test/exi/cb/iso20/authorization.cpp
@@ -27,8 +27,8 @@ SCENARIO("Se/Deserialize authorization messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1});
             REQUIRE(header.timestamp == 1691411798);
 
-            REQUIRE(msg.selected_authorization_service == message_20::Authorization::EIM);
-            REQUIRE(msg.eim_as_req_authorization_mode.has_value() == true);
+            REQUIRE(msg.selected_authorization_service == message_20::datatypes::Authorization::EIM);
+            REQUIRE(std::holds_alternative<message_20::datatypes::EIM_ASReqAuthorizationMode>(msg.authorization_mode));
         }
     }
 
@@ -39,8 +39,8 @@ SCENARIO("Se/Deserialize authorization messages") {
         message_20::AuthorizationResponse res;
 
         res.header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
-        res.response_code = message_20::ResponseCode::OK;
-        res.evse_processing = message_20::Processing::Finished;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.evse_processing = message_20::datatypes::Processing::Finished;
 
         std::vector<uint8_t> expected = {0x80, 0x04, 0x04, 0x79, 0x0c, 0x8a, 0xdc, 0xee, 0xee, 0x09,
                                          0x68, 0x8d, 0x6c, 0xac, 0x3a, 0x60, 0x62, 0x00, 0x00};

--- a/test/exi/cb/iso20/authorization_setup.cpp
+++ b/test/exi/cb/iso20/authorization_setup.cpp
@@ -36,10 +36,10 @@ SCENARIO("Se/Deserialize authorization setup messages") {
         message_20::AuthorizationSetupResponse res;
 
         res.header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
-        res.response_code = message_20::ResponseCode::OK;
-        res.authorization_services = {{message_20::Authorization::EIM}};
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.authorization_services = {{message_20::datatypes::Authorization::EIM}};
         res.certificate_installation_service = true;
-        res.authorization_mode = message_20::AuthorizationSetupResponse::EIM_ASResAuthorizationMode();
+        res.authorization_mode = message_20::datatypes::EIM_ASResAuthorizationMode();
 
         std::vector<uint8_t> expected = {0x80, 0x0c, 0x04, 0x79, 0x0c, 0x8a, 0xdc, 0xee, 0xee, 0x09,
                                          0x68, 0x8d, 0x6c, 0xac, 0x3a, 0x60, 0x62, 0x00, 0x05, 0x00};
@@ -54,12 +54,12 @@ SCENARIO("Se/Deserialize authorization setup messages") {
         message_20::AuthorizationSetupResponse res;
 
         res.header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
-        res.response_code = message_20::ResponseCode::OK;
-        res.authorization_services = {{message_20::Authorization::EIM}, {message_20::Authorization::PnC}};
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.authorization_services = {{message_20::datatypes::Authorization::EIM},
+                                      {message_20::datatypes::Authorization::PnC}};
         res.certificate_installation_service = true;
 
-        auto& mode =
-            res.authorization_mode.emplace<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>();
+        auto& mode = res.authorization_mode.emplace<message_20::datatypes::PnC_ASResAuthorizationMode>();
 
         mode.gen_challenge = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 

--- a/test/exi/cb/iso20/dc_cable_check.cpp
+++ b/test/exi/cb/iso20/dc_cable_check.cpp
@@ -34,8 +34,8 @@ SCENARIO("Se/Deserialize dc cable check messages") {
         message_20::DC_CableCheckResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456328};
-        res.response_code = message_20::ResponseCode::OK;
-        res.processing = message_20::Processing::Ongoing;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.processing = message_20::datatypes::Processing::Ongoing;
 
         std::vector<uint8_t> expected = {0x80, 0x30, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c,
                                          0x4d, 0x8c, 0x8b, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x10};
@@ -50,8 +50,8 @@ SCENARIO("Se/Deserialize dc cable check messages") {
         message_20::DC_CableCheckResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456331};
-        res.response_code = message_20::ResponseCode::OK;
-        res.processing = message_20::Processing::Finished;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.processing = message_20::datatypes::Processing::Finished;
 
         std::vector<uint8_t> expected = {0x80, 0x30, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c,
                                          0x4d, 0x8c, 0xbb, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x00};

--- a/test/exi/cb/iso20/dc_charge_loop.cpp
+++ b/test/exi/cb/iso20/dc_charge_loop.cpp
@@ -7,6 +7,8 @@
 
 using namespace iso15118;
 
+namespace dt = iso15118::message_20::datatypes;
+
 SCENARIO("Se/Deserialize dc charge loop messages") {
 
     GIVEN("Deserialize dc_charge_loop_req") {
@@ -27,14 +29,14 @@ SCENARIO("Se/Deserialize dc charge loop messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456333);
             REQUIRE(msg.meter_info_requested == false);
-            REQUIRE(message_20::from_RationalNumber(msg.present_voltage) == 400);
+            REQUIRE(dt::from_RationalNumber(msg.present_voltage) == 400);
 
-            using ScheduledMode = message_20::DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode;
+            using ScheduledMode = message_20::datatypes::Scheduled_DC_CLReqControlMode;
 
             REQUIRE(std::holds_alternative<ScheduledMode>(msg.control_mode));
             const auto& control_mode = std::get<ScheduledMode>(msg.control_mode);
-            REQUIRE(message_20::from_RationalNumber(control_mode.target_current) == 20);
-            REQUIRE(message_20::from_RationalNumber(control_mode.target_voltage) == 400);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_current) == 20);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_voltage) == 400);
         }
     }
 
@@ -58,7 +60,7 @@ SCENARIO("Se/Deserialize dc charge loop messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x64, 0xEA, 0xED, 0x3D, 0x8E, 0x20, 0xC9, 0x59});
             REQUIRE(header.timestamp == 1727440880);
             REQUIRE(msg.meter_info_requested == false);
-            REQUIRE(message_20::from_RationalNumber(msg.present_voltage) == 400.0f);
+            REQUIRE(dt::from_RationalNumber(msg.present_voltage) == 400.0f);
 
             REQUIRE(msg.display_parameters.has_value() == true);
             const auto& display_parameters = msg.display_parameters.value();
@@ -66,19 +68,19 @@ SCENARIO("Se/Deserialize dc charge loop messages") {
             REQUIRE(display_parameters.present_soc.value_or(0) == 10);
             REQUIRE(display_parameters.charging_complete.value_or(true) == false);
 
-            using DynamicMode = message_20::DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode;
+            using DynamicMode = message_20::datatypes::Dynamic_DC_CLReqControlMode;
 
             REQUIRE(std::holds_alternative<DynamicMode>(msg.control_mode));
             const auto& control_mode = std::get<DynamicMode>(msg.control_mode);
 
-            REQUIRE(message_20::from_RationalNumber(control_mode.target_energy_request) == 60000.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.max_energy_request) == 60000.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.min_energy_request) == 1.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.max_charge_power) == 150000.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.min_charge_power) == 0.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.max_charge_current) == 300.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.max_voltage) == 900.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.min_voltage) == 150.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_energy_request) == 60000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_energy_request) == 60000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.min_energy_request) == 1.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_power) == 150000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.min_charge_power) == 0.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_current) == 300.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_voltage) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.min_voltage) == 150.0f);
         }
     }
 
@@ -87,8 +89,8 @@ SCENARIO("Se/Deserialize dc charge loop messages") {
         message_20::DC_ChargeLoopResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456334};
-        res.response_code = message_20::ResponseCode::OK;
-        res.control_mode.emplace<message_20::DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode>();
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.control_mode.emplace<message_20::datatypes::Scheduled_DC_CLResControlMode>();
         res.current_limit_achieved = true;
         res.power_limit_achieved = true;
         res.voltage_limit_achieved = true;

--- a/test/exi/cb/iso20/dc_charge_parameter_discovery.cpp
+++ b/test/exi/cb/iso20/dc_charge_parameter_discovery.cpp
@@ -28,16 +28,16 @@ SCENARIO("Se/Deserialize dc charge parameter discovery messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456323);
 
-            using DC_ModeReq = message_20::DC_ChargeParameterDiscoveryRequest::DC_CPDReqEnergyTransferMode;
+            using DC_ModeReq = message_20::datatypes::DC_CPDReqEnergyTransferMode;
 
             REQUIRE(std::holds_alternative<DC_ModeReq>(msg.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeReq>(msg.transfer_mode);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.max_charge_current) == 300);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.max_charge_power) == 150000);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.max_voltage) == 900);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.min_charge_current) == 10);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.min_charge_power) == 100);
-            REQUIRE(message_20::from_RationalNumber(transfer_mode.min_voltage) == 10);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.max_charge_current) == 300);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.max_charge_power) == 150000);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.max_voltage) == 900);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.min_charge_current) == 10);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.min_charge_power) == 100);
+            REQUIRE(message_20::datatypes::from_RationalNumber(transfer_mode.min_voltage) == 10);
         }
     }
 
@@ -45,12 +45,12 @@ SCENARIO("Se/Deserialize dc charge parameter discovery messages") {
 
     GIVEN("Serialize dc_charge_parameter_discovery_res") {
 
-        using DC_ModeRes = message_20::DC_ChargeParameterDiscoveryResponse::DC_CPDResEnergyTransferMode;
+        using DC_ModeRes = message_20::datatypes::DC_CPDResEnergyTransferMode;
 
         message_20::DC_ChargeParameterDiscoveryResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456324};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
         auto& mode = res.transfer_mode.emplace<DC_ModeRes>();
         mode.max_charge_current = {2000, -1};
         mode.max_charge_power = {2208, 1};

--- a/test/exi/cb/iso20/dc_pre_charge.cpp
+++ b/test/exi/cb/iso20/dc_pre_charge.cpp
@@ -26,9 +26,9 @@ SCENARIO("Se/Deserialize dc pre charge messages") {
 
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456331);
-            REQUIRE(msg.processing == message_20::Processing::Ongoing);
-            REQUIRE(message_20::from_RationalNumber(msg.present_voltage) == 400);
-            REQUIRE(message_20::from_RationalNumber(msg.target_voltage) == 400);
+            REQUIRE(msg.processing == message_20::datatypes::Processing::Ongoing);
+            REQUIRE(message_20::datatypes::from_RationalNumber(msg.present_voltage) == 400);
+            REQUIRE(message_20::datatypes::from_RationalNumber(msg.target_voltage) == 400);
         }
     }
 
@@ -37,7 +37,7 @@ SCENARIO("Se/Deserialize dc pre charge messages") {
         message_20::DC_PreChargeResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456332};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
         res.present_voltage = {4000, -1};
 
         std::vector<uint8_t> expected = {0x80, 0x48, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c,

--- a/test/exi/cb/iso20/dc_welding_detection.cpp
+++ b/test/exi/cb/iso20/dc_welding_detection.cpp
@@ -27,7 +27,7 @@ SCENARIO("Se/Deserialize dc welding detection messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456341);
 
-            REQUIRE(msg.processing == message_20::Processing::Ongoing);
+            REQUIRE(msg.processing == message_20::datatypes::Processing::Ongoing);
         }
     }
 
@@ -36,7 +36,7 @@ SCENARIO("Se/Deserialize dc welding detection messages") {
         message_20::DC_WeldingDetectionResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456341};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
         res.present_voltage = {0, 0};
 
         std::vector<uint8_t> expected = {0x80, 0x50, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d,

--- a/test/exi/cb/iso20/power_delivery.cpp
+++ b/test/exi/cb/iso20/power_delivery.cpp
@@ -26,21 +26,19 @@ SCENARIO("Se/Deserialize power delivery messages") {
 
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456333);
-            REQUIRE(msg.processing == message_20::Processing::Finished);
-            REQUIRE(msg.charge_progress == message_20::PowerDeliveryRequest::Progress::Start);
+            REQUIRE(msg.processing == message_20::datatypes::Processing::Finished);
+            REQUIRE(msg.charge_progress == message_20::datatypes::Progress::Start);
 
             REQUIRE(msg.power_profile.has_value() == true);
             auto& power_profile = msg.power_profile.value();
             REQUIRE(power_profile.time_anchor == 0);
             REQUIRE(power_profile.entries[0].duration == 23);
-            REQUIRE(message_20::from_RationalNumber(power_profile.entries[0].power) == 1000);
+            REQUIRE(message_20::datatypes::from_RationalNumber(power_profile.entries[0].power) == 1000);
 
-            REQUIRE(std::holds_alternative<message_20::PowerDeliveryRequest::Scheduled_EVPPTControlMode>(
-                power_profile.control_mode));
-            const auto& mode =
-                std::get<message_20::PowerDeliveryRequest::Scheduled_EVPPTControlMode>(power_profile.control_mode);
-            REQUIRE(mode.power_tolerance_acceptance ==
-                    message_20::PowerDeliveryRequest::PowerToleranceAcceptance::Confirmed);
+            REQUIRE(
+                std::holds_alternative<message_20::datatypes::Scheduled_EVPPTControlMode>(power_profile.control_mode));
+            const auto& mode = std::get<message_20::datatypes::Scheduled_EVPPTControlMode>(power_profile.control_mode);
+            REQUIRE(mode.power_tolerance_acceptance == message_20::datatypes::PowerToleranceAcceptance::Confirmed);
             REQUIRE(mode.selected_schedule == 1);
         }
     }
@@ -50,7 +48,7 @@ SCENARIO("Se/Deserialize power delivery messages") {
         message_20::PowerDeliveryResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456333};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
 
         std::vector<uint8_t> expected = {0x80, 0x58, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c,
                                          0x4d, 0x8c, 0xdb, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x40};

--- a/test/exi/cb/iso20/schedule_exchange.cpp
+++ b/test/exi/cb/iso20/schedule_exchange.cpp
@@ -7,6 +7,8 @@
 
 using namespace iso15118;
 
+namespace dt = iso15118::message_20::datatypes;
+
 SCENARIO("Se/Deserialize schedule_exchange messages") {
 
     GIVEN("Serialize schedule_exchange_req - scheduled mode") {
@@ -34,26 +36,24 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
 
             REQUIRE(msg.max_supporting_points == 1024);
 
-            REQUIRE(std::holds_alternative<message_20::ScheduleExchangeRequest::Scheduled_SEReqControlMode>(
-                msg.control_mode));
-            auto& control_mode =
-                std::get<message_20::ScheduleExchangeRequest::Scheduled_SEReqControlMode>(msg.control_mode);
+            REQUIRE(std::holds_alternative<dt::Scheduled_SEReqControlMode>(msg.control_mode));
+            auto& control_mode = std::get<dt::Scheduled_SEReqControlMode>(msg.control_mode);
 
             REQUIRE(control_mode.departure_time.has_value() == true);
             REQUIRE(control_mode.departure_time == 7200);
             REQUIRE(control_mode.target_energy.has_value() == true);
-            REQUIRE(message_20::from_RationalNumber(*control_mode.target_energy) == 10000.0f);
+            REQUIRE(dt::from_RationalNumber(*control_mode.target_energy) == 10000.0f);
             REQUIRE(control_mode.max_energy.has_value() == true);
-            REQUIRE(message_20::from_RationalNumber(*control_mode.max_energy) == 20000.0f);
+            REQUIRE(dt::from_RationalNumber(*control_mode.max_energy) == 20000.0f);
             REQUIRE(control_mode.min_energy.has_value() == true);
-            REQUIRE(message_20::from_RationalNumber(*control_mode.min_energy) == 0.05f);
+            REQUIRE(dt::from_RationalNumber(*control_mode.min_energy) == 0.05f);
 
             REQUIRE(control_mode.energy_offer.has_value() == true);
             auto& ev_energy_offer = control_mode.energy_offer.value();
             REQUIRE(ev_energy_offer.power_schedule.time_anchor == 0);
             REQUIRE(ev_energy_offer.power_schedule.entries.size() == 1);
             REQUIRE(ev_energy_offer.power_schedule.entries.at(0).duration == 3600);
-            REQUIRE(message_20::from_RationalNumber(ev_energy_offer.power_schedule.entries.at(0).power) == 10000.0f);
+            REQUIRE(dt::from_RationalNumber(ev_energy_offer.power_schedule.entries.at(0).power) == 10000.0f);
 
             REQUIRE(ev_energy_offer.absolute_price_schedule.time_anchor == 0);
             REQUIRE(ev_energy_offer.absolute_price_schedule.currency == "EUR");
@@ -62,12 +62,12 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
             REQUIRE(ev_energy_offer.absolute_price_schedule.price_rule_stacks.size() == 1);
             REQUIRE(ev_energy_offer.absolute_price_schedule.price_rule_stacks.at(0).duration == 0);
             REQUIRE(ev_energy_offer.absolute_price_schedule.price_rule_stacks.at(0).price_rules.size() == 1);
-            REQUIRE(message_20::from_RationalNumber(
+            REQUIRE(dt::from_RationalNumber(
                         ev_energy_offer.absolute_price_schedule.price_rule_stacks.at(0).price_rules.at(0).energy_fee) ==
                     0);
-            REQUIRE(message_20::from_RationalNumber(ev_energy_offer.absolute_price_schedule.price_rule_stacks.at(0)
-                                                        .price_rules.at(0)
-                                                        .power_range_start) == 0);
+            REQUIRE(dt::from_RationalNumber(ev_energy_offer.absolute_price_schedule.price_rule_stacks.at(0)
+                                                .price_rules.at(0)
+                                                .power_range_start) == 0);
         }
     }
 
@@ -92,21 +92,19 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
 
             REQUIRE(msg.max_supporting_points == 1024);
 
-            REQUIRE(std::holds_alternative<message_20::ScheduleExchangeRequest::Dynamic_SEReqControlMode>(
-                msg.control_mode));
-            auto& control_mode =
-                std::get<message_20::ScheduleExchangeRequest::Dynamic_SEReqControlMode>(msg.control_mode);
+            REQUIRE(std::holds_alternative<dt::Dynamic_SEReqControlMode>(msg.control_mode));
+            auto& control_mode = std::get<dt::Dynamic_SEReqControlMode>(msg.control_mode);
 
             REQUIRE(control_mode.departure_time == 7200);
             REQUIRE(control_mode.minimum_soc == 30);
             REQUIRE(control_mode.target_soc == 80);
-            REQUIRE(message_20::from_RationalNumber(control_mode.target_energy) == 40000.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.max_energy) == 60000.0f);
-            REQUIRE(message_20::from_RationalNumber(control_mode.min_energy) == -20000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_energy) == 40000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_energy) == 60000.0f);
+            REQUIRE(dt::from_RationalNumber(control_mode.min_energy) == -20000.0f);
             REQUIRE(control_mode.max_v2x_energy.has_value() == true);
-            REQUIRE(message_20::from_RationalNumber(*control_mode.max_v2x_energy) == 5000.0f);
+            REQUIRE(dt::from_RationalNumber(*control_mode.max_v2x_energy) == 5000.0f);
             REQUIRE(control_mode.min_v2x_energy.has_value() == true);
-            REQUIRE(message_20::from_RationalNumber(*control_mode.min_v2x_energy) == 0.0f);
+            REQUIRE(dt::from_RationalNumber(*control_mode.min_v2x_energy) == 0.0f);
         }
     }
 
@@ -115,11 +113,10 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
         message_20::ScheduleExchangeResponse res;
 
         res.header = message_20::Header{{0x47, 0xFD, 0x3B, 0x4F, 0x13, 0x25, 0x57, 0xCA}, 1727082831};
-        res.response_code = message_20::ResponseCode::OK;
-        res.processing = message_20::Processing::Finished;
-        auto& control_mode =
-            res.control_mode.emplace<message_20::ScheduleExchangeResponse::Scheduled_SEResControlMode>();
-        message_20::ScheduleExchangeResponse::ScheduleTuple tuple;
+        res.response_code = dt::ResponseCode::OK;
+        res.processing = dt::Processing::Finished;
+        auto& control_mode = res.control_mode.emplace<dt::Scheduled_SEResControlMode>();
+        dt::ScheduleTuple tuple;
 
         tuple.schedule_tuple_id = 1;
         tuple.charging_schedule.power_schedule.time_anchor = 1727082831;
@@ -140,18 +137,16 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
         message_20::ScheduleExchangeResponse res;
 
         res.header = message_20::Header{{0x47, 0xFD, 0x3B, 0x4F, 0x13, 0x25, 0x57, 0xCA}, 1727082831};
-        res.response_code = message_20::ResponseCode::OK;
-        res.processing = message_20::Processing::Finished;
-        auto& control_mode =
-            res.control_mode.emplace<message_20::ScheduleExchangeResponse::Scheduled_SEResControlMode>();
-        message_20::ScheduleExchangeResponse::ScheduleTuple tuple;
+        res.response_code = dt::ResponseCode::OK;
+        res.processing = dt::Processing::Finished;
+        auto& control_mode = res.control_mode.emplace<dt::Scheduled_SEResControlMode>();
+        dt::ScheduleTuple tuple;
 
         tuple.schedule_tuple_id = 1;
         tuple.charging_schedule.power_schedule.time_anchor = 1727082831;
         tuple.charging_schedule.power_schedule.entries.push_back({86400, {2208, 1}, std::nullopt, std::nullopt});
 
-        auto& price_level =
-            tuple.charging_schedule.price_schedule.emplace<message_20::ScheduleExchangeResponse::PriceLevelSchedule>();
+        auto& price_level = tuple.charging_schedule.price_schedule.emplace<dt::PriceLevelSchedule>();
         price_level.time_anchor = 1727082831;
         price_level.price_schedule_id = 1;
         price_level.number_of_price_levels = 0;
@@ -177,9 +172,9 @@ SCENARIO("Se/Deserialize schedule_exchange messages") {
         message_20::ScheduleExchangeResponse res;
 
         res.header = message_20::Header{{0x39, 0x20, 0xB0, 0x04, 0x6E, 0x4A, 0xF9, 0x09}, 1727076439};
-        res.response_code = message_20::ResponseCode::OK;
-        res.processing = message_20::Processing::Finished;
-        auto& control_mode = res.control_mode.emplace<message_20::ScheduleExchangeResponse::Dynamic_SEResControlMode>();
+        res.response_code = dt::ResponseCode::OK;
+        res.processing = dt::Processing::Finished;
+        auto& control_mode = res.control_mode.emplace<dt::Dynamic_SEResControlMode>();
         control_mode.departure_time = 2000;
 
         std::vector<uint8_t> expected = {0x80, 0x70, 0x04, 0x1c, 0x90, 0x58, 0x02, 0x37, 0x25, 0x7c, 0x84,

--- a/test/exi/cb/iso20/service_detail.cpp
+++ b/test/exi/cb/iso20/service_detail.cpp
@@ -28,7 +28,7 @@ SCENARIO("Se/Deserialize service_detail messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x04, 0xEB, 0xFF, 0x2C, 0x94, 0x59, 0xDB, 0x42});
             REQUIRE(header.timestamp == 1692009443);
 
-            REQUIRE(msg.service == message_20::ServiceCategory::AC_BPT);
+            REQUIRE(msg.service == message_20::datatypes::ServiceCategory::AC_BPT);
         }
     }
 
@@ -37,13 +37,13 @@ SCENARIO("Se/Deserialize service_detail messages") {
         message_20::ServiceDetailResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
-        res.response_code = message_20::ResponseCode::OK;
-        res.service = message_20::ServiceCategory::DC;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
+        res.service = message_20::datatypes::ServiceCategory::DC;
 
-        const auto list =
-            message_20::DcParameterList{message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-                                        message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing};
-        res.service_parameter_list = {message_20::ServiceDetailResponse::ParameterSet(0, list)};
+        const auto list = message_20::datatypes::DcParameterList{
+            message_20::datatypes::DcConnector::Extended, message_20::datatypes::ControlMode::Scheduled,
+            message_20::datatypes::MobilityNeedsMode::ProvidedByEvcc, message_20::datatypes::Pricing::NoPricing};
+        res.service_parameter_list = {message_20::datatypes::ParameterSet(0, list)};
 
         std::vector<uint8_t> expected = {
             0x80, 0x78, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60,

--- a/test/exi/cb/iso20/service_discovery.cpp
+++ b/test/exi/cb/iso20/service_discovery.cpp
@@ -37,10 +37,10 @@ SCENARIO("Se/Deserialize service_discovery messages") {
         message_20::ServiceDiscoveryResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456322};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
         res.service_renegotiation_supported = false;
-        res.energy_transfer_service_list = {{message_20::ServiceCategory::DC, false},
-                                            {message_20::ServiceCategory::DC_BPT, false}};
+        res.energy_transfer_service_list = {{message_20::datatypes::ServiceCategory::DC, false},
+                                            {message_20::datatypes::ServiceCategory::DC_BPT, false}};
 
         std::vector<uint8_t> expected = {0x80, 0x80, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c,
                                          0x2b, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x00, 0x02, 0x00, 0x01, 0x80, 0x50};

--- a/test/exi/cb/iso20/service_selection.cpp
+++ b/test/exi/cb/iso20/service_selection.cpp
@@ -28,7 +28,7 @@ SCENARIO("Se/Deserialize service_selection messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x04, 0xEB, 0xFF, 0x2C, 0x94, 0x59, 0xDB, 0x42});
             REQUIRE(header.timestamp == 1692009443);
 
-            REQUIRE(msg.selected_energy_transfer_service.service_id == message_20::ServiceCategory::AC_BPT);
+            REQUIRE(msg.selected_energy_transfer_service.service_id == message_20::datatypes::ServiceCategory::AC_BPT);
             REQUIRE(msg.selected_energy_transfer_service.parameter_set_id == 1);
         }
     }
@@ -40,7 +40,7 @@ SCENARIO("Se/Deserialize service_selection messages") {
         message_20::ServiceSelectionResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
 
         std::vector<uint8_t> expected = {0x80, 0x88, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c,
                                          0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x00};

--- a/test/exi/cb/iso20/session_setup.cpp
+++ b/test/exi/cb/iso20/session_setup.cpp
@@ -37,8 +37,8 @@ SCENARIO("Se/Deserialize session setup messages") {
 
         const auto header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
 
-        const auto res =
-            message_20::SessionSetupResponse{header, message_20::ResponseCode::OK_NewSessionEstablished, "UK123E1234"};
+        const auto res = message_20::SessionSetupResponse{
+            header, message_20::datatypes::ResponseCode::OK_NewSessionEstablished, "UK123E1234"};
 
         std::vector<uint8_t> expected = {0x80, 0x90, 0x04, 0x79, 0x0c, 0x8a, 0xdc, 0xee, 0xee, 0x09,
                                          0x68, 0x8d, 0x6c, 0xac, 0x3a, 0x60, 0x62, 0x04, 0x03, 0x15,

--- a/test/exi/cb/iso20/session_stop.cpp
+++ b/test/exi/cb/iso20/session_stop.cpp
@@ -27,7 +27,7 @@ SCENARIO("Se/Deserialize session stop messages") {
             REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
             REQUIRE(header.timestamp == 1725456343);
 
-            REQUIRE(msg.charging_session == message_20::ChargingSession::Terminate);
+            REQUIRE(msg.charging_session == message_20::datatypes::ChargingSession::Terminate);
         }
     }
 
@@ -36,7 +36,7 @@ SCENARIO("Se/Deserialize session stop messages") {
         message_20::SessionStopResponse res;
 
         res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456343};
-        res.response_code = message_20::ResponseCode::OK;
+        res.response_code = message_20::datatypes::ResponseCode::OK;
 
         std::vector<uint8_t> expected = {0x80, 0x98, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c,
                                          0x4d, 0x8d, 0x7b, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x00};

--- a/test/iso15118/fsm/d20_transitions.cpp
+++ b/test/iso15118/fsm/d20_transitions.cpp
@@ -14,12 +14,13 @@ using namespace iso15118;
 SCENARIO("ISO15118-20 state transitions") {
 
     const auto evse_id = std::string("everest se");
-    const std::vector<message_20::ServiceCategory> supported_energy_services = {message_20::ServiceCategory::DC};
+    const std::vector<message_20::datatypes::ServiceCategory> supported_energy_services = {
+        message_20::datatypes::ServiceCategory::DC};
     const auto cert_install{false};
-    const std::vector<message_20::Authorization> auth_services = {message_20::Authorization::EIM};
+    const std::vector<message_20::datatypes::Authorization> auth_services = {message_20::datatypes::Authorization::EIM};
     const d20::DcTransferLimits dc_limits;
     const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
-        {message_20::ControlMode::Scheduled, message_20::MobilityNeedsMode::ProvidedByEvcc}};
+        {message_20::datatypes::ControlMode::Scheduled, message_20::datatypes::MobilityNeedsMode::ProvidedByEvcc}};
 
     const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services, cert_install,
                                           dc_limits, control_mobility_modes};

--- a/test/iso15118/session/feedback.cpp
+++ b/test/iso15118/session/feedback.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118::session;
 
+namespace dt = iso15118::message_20::datatypes;
+
 struct FeedbackResults {
     feedback::Signal signal;
     float target_voltage;
@@ -61,21 +63,20 @@ SCENARIO("Feedback Tests") {
 
     GIVEN("Test dc_charge_loop_req - bpt scheduled") {
 
-        using BPT_ScheduleReqControlMode =
-            iso15118::message_20::DC_ChargeLoopRequest::BPT_Scheduled_DC_CLReqControlMode;
+        using BPT_ScheduleReqControlMode = dt::BPT_Scheduled_DC_CLReqControlMode;
 
         const BPT_ScheduleReqControlMode expected = {{
                                                          {std::nullopt, std::nullopt, std::nullopt},
                                                          {4402, -1},
                                                          {30, 0},
                                                          std::nullopt,
-                                                         iso15118::message_20::RationalNumber{34, 0},
+                                                         dt::RationalNumber{34, 0},
                                                          std::nullopt,
                                                          std::nullopt,
                                                          std::nullopt,
                                                      },
-                                                     iso15118::message_20::RationalNumber{11, 3},
-                                                     iso15118::message_20::RationalNumber{32, 1},
+                                                     dt::RationalNumber{11, 3},
+                                                     dt::RationalNumber{32, 1},
                                                      std::nullopt};
 
         feedback.dc_charge_loop_req(expected);
@@ -90,31 +91,31 @@ SCENARIO("Feedback Tests") {
             REQUIRE(bpt_scheduled_control_mode->max_energy_request.has_value() == false);
             REQUIRE(bpt_scheduled_control_mode->min_energy_request.has_value() == false);
 
-            REQUIRE(from_RationalNumber(bpt_scheduled_control_mode->target_current) ==
-                    from_RationalNumber(expected.target_current));
-            REQUIRE(from_RationalNumber(bpt_scheduled_control_mode->target_voltage) ==
-                    from_RationalNumber(expected.target_voltage));
+            REQUIRE(dt::from_RationalNumber(bpt_scheduled_control_mode->target_current) ==
+                    dt::from_RationalNumber(expected.target_current));
+            REQUIRE(dt::from_RationalNumber(bpt_scheduled_control_mode->target_voltage) ==
+                    dt::from_RationalNumber(expected.target_voltage));
             REQUIRE(bpt_scheduled_control_mode->max_charge_power.has_value() == false);
             REQUIRE(bpt_scheduled_control_mode->min_charge_power.has_value() == true);
-            REQUIRE(from_RationalNumber(*bpt_scheduled_control_mode->min_charge_power) ==
-                    from_RationalNumber(expected.min_charge_power.value_or(iso15118::message_20::RationalNumber{})));
+            REQUIRE(dt::from_RationalNumber(*bpt_scheduled_control_mode->min_charge_power) ==
+                    dt::from_RationalNumber(expected.min_charge_power.value_or(dt::RationalNumber{})));
             REQUIRE(bpt_scheduled_control_mode->max_charge_current.has_value() == false);
             REQUIRE(bpt_scheduled_control_mode->max_voltage.has_value() == false);
             REQUIRE(bpt_scheduled_control_mode->min_voltage.has_value() == false);
 
             REQUIRE(bpt_scheduled_control_mode->max_discharge_power.has_value() == true);
-            REQUIRE(from_RationalNumber(*bpt_scheduled_control_mode->max_discharge_power) ==
-                    from_RationalNumber(expected.max_discharge_power.value_or(iso15118::message_20::RationalNumber{})));
+            REQUIRE(dt::from_RationalNumber(*bpt_scheduled_control_mode->max_discharge_power) ==
+                    dt::from_RationalNumber(expected.max_discharge_power.value_or(dt::RationalNumber{})));
             REQUIRE(bpt_scheduled_control_mode->min_discharge_power.has_value() == true);
-            REQUIRE(from_RationalNumber(*bpt_scheduled_control_mode->min_discharge_power) ==
-                    from_RationalNumber(expected.min_discharge_power.value_or(iso15118::message_20::RationalNumber{})));
+            REQUIRE(dt::from_RationalNumber(*bpt_scheduled_control_mode->min_discharge_power) ==
+                    dt::from_RationalNumber(expected.min_discharge_power.value_or(dt::RationalNumber{})));
             REQUIRE(bpt_scheduled_control_mode->max_discharge_current.has_value() == false);
         }
     }
 
     GIVEN("Test dc_charge_loop_req - dynamic") {
 
-        using DynamicReqControlMode = iso15118::message_20::DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode;
+        using DynamicReqControlMode = dt::Dynamic_DC_CLReqControlMode;
 
         const DynamicReqControlMode expected = {
             {std::nullopt, {2344, 1}, {30, 3}, {10, 3}}, {22, 3}, {0, 0}, {5, 2}, {9, 2}, {25, 1}};
@@ -129,23 +130,23 @@ SCENARIO("Feedback Tests") {
 
             REQUIRE(dynamic_control_mode->departure_time.has_value() == false);
 
-            REQUIRE(from_RationalNumber(dynamic_control_mode->target_energy_request) ==
-                    from_RationalNumber(expected.target_energy_request));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->max_energy_request) ==
-                    from_RationalNumber(expected.max_energy_request));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->min_energy_request) ==
-                    from_RationalNumber(expected.min_energy_request));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->target_energy_request) ==
+                    dt::from_RationalNumber(expected.target_energy_request));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->max_energy_request) ==
+                    dt::from_RationalNumber(expected.max_energy_request));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->min_energy_request) ==
+                    dt::from_RationalNumber(expected.min_energy_request));
 
-            REQUIRE(from_RationalNumber(dynamic_control_mode->max_charge_power) ==
-                    from_RationalNumber(expected.max_charge_power));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->min_charge_power) ==
-                    from_RationalNumber(expected.min_charge_power));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->max_charge_current) ==
-                    from_RationalNumber(expected.max_charge_current));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->max_voltage) ==
-                    from_RationalNumber(expected.max_voltage));
-            REQUIRE(from_RationalNumber(dynamic_control_mode->min_voltage) ==
-                    from_RationalNumber(expected.min_voltage));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->max_charge_power) ==
+                    dt::from_RationalNumber(expected.max_charge_power));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->min_charge_power) ==
+                    dt::from_RationalNumber(expected.min_charge_power));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->max_charge_current) ==
+                    dt::from_RationalNumber(expected.max_charge_current));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->max_voltage) ==
+                    dt::from_RationalNumber(expected.max_voltage));
+            REQUIRE(dt::from_RationalNumber(dynamic_control_mode->min_voltage) ==
+                    dt::from_RationalNumber(expected.min_voltage));
         }
     }
 
@@ -189,15 +190,13 @@ SCENARIO("Feedback Tests") {
     }
 
     GIVEN("Test display_parameters") {
-        const iso15118::message_20::DisplayParameters expected{40,           std::nullopt, 95,           std::nullopt,
-                                                               std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                                                               std::nullopt, std::nullopt};
+        const dt::DisplayParameters expected{40,           std::nullopt, 95,           std::nullopt, std::nullopt,
+                                             std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt};
 
         feedback.dc_charge_loop_req(expected);
 
         THEN("display_parameters should be like expected") {
-            const auto* display_parameters =
-                std::get_if<iso15118::message_20::DisplayParameters>(&feedback_results.dc_charge_loop_req);
+            const auto* display_parameters = std::get_if<dt::DisplayParameters>(&feedback_results.dc_charge_loop_req);
             REQUIRE(display_parameters->present_soc.has_value() == true);
             REQUIRE(*display_parameters->present_soc == expected.present_soc.value_or(0));
             REQUIRE(display_parameters->min_soc.has_value() == false);
@@ -212,8 +211,7 @@ SCENARIO("Feedback Tests") {
 
         THEN("dc_present_voltage should be like expected") {
             const auto* present_voltage = std::get_if<feedback::PresentVoltage>(&feedback_results.dc_charge_loop_req);
-            REQUIRE(iso15118::message_20::from_RationalNumber(*present_voltage) ==
-                    iso15118::message_20::from_RationalNumber(expected));
+            REQUIRE(dt::from_RationalNumber(*present_voltage) == dt::from_RationalNumber(expected));
         }
     }
 

--- a/test/iso15118/states/authorization.cpp
+++ b/test/iso15118/states/authorization.cpp
@@ -5,7 +5,10 @@
 #include <iso15118/detail/d20/state/authorization.hpp>
 
 using namespace iso15118;
-using AuthStatus = message_20::AuthStatus;
+
+namespace dt = message_20::datatypes;
+
+using AuthStatus = message_20::datatypes::AuthStatus;
 
 SCENARIO("Authorization state handling") {
 
@@ -16,34 +19,34 @@ SCENARIO("Authorization state handling") {
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.selected_authorization_service = message_20::Authorization::EIM;
-        req.eim_as_req_authorization_mode.emplace();
+        req.selected_authorization_service = dt::Authorization::EIM;
+        req.authorization_mode.emplace<dt::EIM_ASReqAuthorizationMode>();
 
         const auto res = d20::state::handle_request(req, d20::Session(), AuthStatus::Pending);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
-            REQUIRE(res.evse_processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.evse_processing == dt::Processing::Finished);
         }
     }
 
     GIVEN("Warning - Authorization selection is invalid") {
 
         d20::Session session = d20::Session();
-        session.offered_services.auth_services = {message_20::Authorization::PnC};
+        session.offered_services.auth_services = {dt::Authorization::PnC};
 
         message_20::AuthorizationRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.selected_authorization_service = message_20::Authorization::EIM;
-        req.eim_as_req_authorization_mode.emplace();
+        req.selected_authorization_service = dt::Authorization::EIM;
+        req.authorization_mode.emplace<dt::EIM_ASReqAuthorizationMode>();
 
         const auto res = d20::state::handle_request(req, session, AuthStatus::Pending);
 
         THEN("ResponseCode: FAILED_UnknownSession, EvseProcessing: Finished") {
-            REQUIRE(res.response_code == message_20::ResponseCode::WARNING_AuthorizationSelectionInvalid);
-            REQUIRE(res.evse_processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::WARNING_AuthorizationSelectionInvalid);
+            REQUIRE(res.evse_processing == dt::Processing::Finished);
         }
     }
 
@@ -52,60 +55,60 @@ SCENARIO("Authorization state handling") {
     GIVEN("Warning - EIM Authorization Failure") { // [V2G20-2219]
 
         d20::Session session = d20::Session();
-        session.offered_services.auth_services = {message_20::Authorization::EIM, message_20::Authorization::PnC};
+        session.offered_services.auth_services = {dt::Authorization::EIM, dt::Authorization::PnC};
 
         message_20::AuthorizationRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.selected_authorization_service = message_20::Authorization::EIM;
-        req.eim_as_req_authorization_mode.emplace();
+        req.selected_authorization_service = dt::Authorization::EIM;
+        req.authorization_mode.emplace<dt::EIM_ASReqAuthorizationMode>();
 
         const auto res = d20::state::handle_request(req, session, AuthStatus::Rejected);
 
         THEN("ResponseCode: WARNING_EIMAuthorizationFailure, EvseProcessing: Finished") {
-            REQUIRE(res.response_code == message_20::ResponseCode::WARNING_EIMAuthorizationFailure);
-            REQUIRE(res.evse_processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::WARNING_EIMAuthorizationFailure);
+            REQUIRE(res.evse_processing == dt::Processing::Finished);
         }
     }
 
     GIVEN("Good case - EIM waiting for authorization") {
 
         d20::Session session = d20::Session();
-        session.offered_services.auth_services = {message_20::Authorization::EIM, message_20::Authorization::PnC};
+        session.offered_services.auth_services = {dt::Authorization::EIM, dt::Authorization::PnC};
 
         message_20::AuthorizationRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.selected_authorization_service = message_20::Authorization::EIM;
-        req.eim_as_req_authorization_mode.emplace();
+        req.selected_authorization_service = dt::Authorization::EIM;
+        req.authorization_mode.emplace<dt::EIM_ASReqAuthorizationMode>();
 
         const auto res = d20::state::handle_request(req, session, AuthStatus::Pending);
 
         THEN("ResponseCode: Ok, EvseProcessing: Ongoing") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.evse_processing == message_20::Processing::Ongoing);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.evse_processing == dt::Processing::Ongoing);
         }
     }
 
     GIVEN("Good case - EIM authorized") {
 
         d20::Session session = d20::Session();
-        session.offered_services.auth_services = {message_20::Authorization::EIM, message_20::Authorization::PnC};
+        session.offered_services.auth_services = {dt::Authorization::EIM, dt::Authorization::PnC};
 
         message_20::AuthorizationRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.selected_authorization_service = message_20::Authorization::EIM;
-        req.eim_as_req_authorization_mode.emplace();
+        req.selected_authorization_service = dt::Authorization::EIM;
+        req.authorization_mode.emplace<dt::EIM_ASReqAuthorizationMode>();
 
         const auto res = d20::state::handle_request(req, session, AuthStatus::Accepted);
 
         THEN("ResponseCode: Ok, EvseProcessing: Finished") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.evse_processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.evse_processing == dt::Processing::Finished);
         }
     }
 

--- a/test/iso15118/states/authorization_setup.cpp
+++ b/test/iso15118/states/authorization_setup.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Authorization setup state handling") {
 
     GIVEN("Bad Case - Unknown session") {
@@ -18,17 +20,16 @@ SCENARIO("Authorization setup state handling") {
         session = d20::Session();
 
         const auto cert_install_service = false;
-        const std::vector<message_20::Authorization> authorization_services = {message_20::Authorization::EIM};
+        const std::vector<dt::Authorization> authorization_services = {dt::Authorization::EIM};
 
         const auto res = d20::state::handle_request(req, session, cert_install_service, authorization_services);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
             REQUIRE(res.certificate_installation_service == false);
             REQUIRE(res.authorization_services.size() == 1);
-            REQUIRE(res.authorization_services[0] == message_20::Authorization::EIM);
-            REQUIRE(std::holds_alternative<message_20::AuthorizationSetupResponse::EIM_ASResAuthorizationMode>(
-                res.authorization_mode));
+            REQUIRE(res.authorization_services[0] == dt::Authorization::EIM);
+            REQUIRE(std::holds_alternative<dt::EIM_ASResAuthorizationMode>(res.authorization_mode));
         }
     }
 
@@ -41,18 +42,17 @@ SCENARIO("Authorization setup state handling") {
         req.header.timestamp = 1691411798;
 
         const auto cert_install_service = false;
-        const std::vector<message_20::Authorization> authorization_services = {message_20::Authorization::EIM};
+        const std::vector<dt::Authorization> authorization_services = {dt::Authorization::EIM};
 
         const auto res = d20::state::handle_request(req, session, cert_install_service, authorization_services);
 
         THEN("ResponseCode: Ok, cert_install = false, authorization_servie = EIM") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.certificate_installation_service == false);
             REQUIRE(res.authorization_services.size() == 1);
-            REQUIRE(res.authorization_services[0] == message_20::Authorization::EIM);
-            REQUIRE(std::holds_alternative<message_20::AuthorizationSetupResponse::EIM_ASResAuthorizationMode>(
-                res.authorization_mode));
-            REQUIRE(session.offered_services.auth_services[0] == message_20::Authorization::EIM);
+            REQUIRE(res.authorization_services[0] == dt::Authorization::EIM);
+            REQUIRE(std::holds_alternative<dt::EIM_ASResAuthorizationMode>(res.authorization_mode));
+            REQUIRE(session.offered_services.auth_services[0] == dt::Authorization::EIM);
         }
     }
 
@@ -65,21 +65,19 @@ SCENARIO("Authorization setup state handling") {
         req.header.timestamp = 1691411798;
 
         const auto cert_install_service = false;
-        const std::vector<message_20::Authorization> authorization_services = {message_20::Authorization::PnC};
+        const std::vector<dt::Authorization> authorization_services = {dt::Authorization::PnC};
 
         const auto res = d20::state::handle_request(req, session, cert_install_service, authorization_services);
 
         THEN("ResponseCode: Ok, cert_install = false, authorization_servie = PnC, authorization_mode = PnC_Mode") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.certificate_installation_service == false);
             REQUIRE(res.authorization_services.size() == 1);
-            REQUIRE(res.authorization_services[0] == message_20::Authorization::PnC);
-            REQUIRE(std::holds_alternative<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>(
-                res.authorization_mode));
-            const auto& auth_mode =
-                std::get<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>(res.authorization_mode);
+            REQUIRE(res.authorization_services[0] == dt::Authorization::PnC);
+            REQUIRE(std::holds_alternative<dt::PnC_ASResAuthorizationMode>(res.authorization_mode));
+            const auto& auth_mode = std::get<dt::PnC_ASResAuthorizationMode>(res.authorization_mode);
             REQUIRE(auth_mode.gen_challenge.empty() == false);
-            REQUIRE(session.offered_services.auth_services[0] == message_20::Authorization::PnC);
+            REQUIRE(session.offered_services.auth_services[0] == dt::Authorization::PnC);
         }
     }
 
@@ -92,29 +90,26 @@ SCENARIO("Authorization setup state handling") {
         req.header.timestamp = 1691411798;
 
         const auto cert_install_service = true;
-        const std::vector<message_20::Authorization> authorization_services = {message_20::Authorization::PnC,
-                                                                               message_20::Authorization::EIM};
+        const std::vector<dt::Authorization> authorization_services = {dt::Authorization::PnC, dt::Authorization::EIM};
 
         const auto res = d20::state::handle_request(req, session, cert_install_service, authorization_services);
 
         THEN("ResponseCode: Ok, cert_install = true, authorization_servie = EIM & PnC, authorization_mode = PnC_Mode") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.certificate_installation_service == true);
             REQUIRE(res.authorization_services.size() == 2);
-            REQUIRE((res.authorization_services[0] == message_20::Authorization::EIM ||
-                     res.authorization_services[0] == message_20::Authorization::PnC));
-            REQUIRE((res.authorization_services[1] == message_20::Authorization::EIM ||
-                     res.authorization_services[1] == message_20::Authorization::PnC));
-            REQUIRE(std::holds_alternative<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>(
-                res.authorization_mode));
-            const auto& auth_mode =
-                std::get<message_20::AuthorizationSetupResponse::PnC_ASResAuthorizationMode>(res.authorization_mode);
+            REQUIRE((res.authorization_services[0] == dt::Authorization::EIM ||
+                     res.authorization_services[0] == dt::Authorization::PnC));
+            REQUIRE((res.authorization_services[1] == dt::Authorization::EIM ||
+                     res.authorization_services[1] == dt::Authorization::PnC));
+            REQUIRE(std::holds_alternative<dt::PnC_ASResAuthorizationMode>(res.authorization_mode));
+            const auto& auth_mode = std::get<dt::PnC_ASResAuthorizationMode>(res.authorization_mode);
             REQUIRE(auth_mode.gen_challenge.empty() == false);
 
-            REQUIRE((session.offered_services.auth_services[0] == message_20::Authorization::EIM ||
-                     session.offered_services.auth_services[0] == message_20::Authorization::PnC));
-            REQUIRE((session.offered_services.auth_services[1] == message_20::Authorization::EIM ||
-                     session.offered_services.auth_services[1] == message_20::Authorization::PnC));
+            REQUIRE((session.offered_services.auth_services[0] == dt::Authorization::EIM ||
+                     session.offered_services.auth_services[0] == dt::Authorization::PnC));
+            REQUIRE((session.offered_services.auth_services[1] == dt::Authorization::EIM ||
+                     session.offered_services.auth_services[1] == dt::Authorization::PnC));
         }
     }
 

--- a/test/iso15118/states/dc_cable_check.cpp
+++ b/test/iso15118/states/dc_cable_check.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("DC cable check state handling") {
     GIVEN("Bad case - Unknown session") {
 
@@ -19,8 +21,8 @@ SCENARIO("DC cable check state handling") {
         const auto res = d20::state::handle_request(req, d20::Session(), false);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
-            REQUIRE(res.processing == message_20::Processing::Ongoing);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.processing == dt::Processing::Ongoing);
         }
     }
 
@@ -34,8 +36,8 @@ SCENARIO("DC cable check state handling") {
         const auto res = d20::state::handle_request(req, session, false);
 
         THEN("ResponseCode: OK, processing: Ongoing") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.processing == message_20::Processing::Ongoing);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.processing == dt::Processing::Ongoing);
         }
     }
 
@@ -49,8 +51,8 @@ SCENARIO("DC cable check state handling") {
         const auto res = d20::state::handle_request(req, session, true);
 
         THEN("ResponseCode: OK, processing: Finished") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.processing == dt::Processing::Finished);
         }
     }
 

--- a/test/iso15118/states/dc_charge_loop.cpp
+++ b/test/iso15118/states/dc_charge_loop.cpp
@@ -10,23 +10,25 @@
 
 using namespace iso15118;
 
-using Scheduled_DC_Req = message_20::DC_ChargeLoopRequest::Scheduled_DC_CLReqControlMode;
-using Scheduled_BPT_DC_Req = message_20::DC_ChargeLoopRequest::BPT_Scheduled_DC_CLReqControlMode;
-using Dynamic_DC_Req = message_20::DC_ChargeLoopRequest::Dynamic_DC_CLReqControlMode;
-using Dynamic_BPT_DC_Req = message_20::DC_ChargeLoopRequest::BPT_Dynamic_DC_CLReqControlMode;
+namespace dt = message_20::datatypes;
 
-using Scheduled_DC_Res = message_20::DC_ChargeLoopResponse::Scheduled_DC_CLResControlMode;
-using Scheduled_BPT_DC_Res = message_20::DC_ChargeLoopResponse::BPT_Scheduled_DC_CLResControlMode;
-using Dynamic_DC_Res = message_20::DC_ChargeLoopResponse::Dynamic_DC_CLResControlMode;
-using Dynamic_BPT_DC_Res = message_20::DC_ChargeLoopResponse::BPT_Dynamic_DC_CLResControlMode;
+using Scheduled_DC_Req = message_20::datatypes::Scheduled_DC_CLReqControlMode;
+using Scheduled_BPT_DC_Req = message_20::datatypes::BPT_Scheduled_DC_CLReqControlMode;
+using Dynamic_DC_Req = message_20::datatypes::Dynamic_DC_CLReqControlMode;
+using Dynamic_BPT_DC_Req = message_20::datatypes::BPT_Dynamic_DC_CLReqControlMode;
+
+using Scheduled_DC_Res = message_20::datatypes::Scheduled_DC_CLResControlMode;
+using Scheduled_BPT_DC_Res = message_20::datatypes::BPT_Scheduled_DC_CLResControlMode;
+using Dynamic_DC_Res = message_20::datatypes::Dynamic_DC_CLResControlMode;
+using Dynamic_BPT_DC_Res = message_20::datatypes::BPT_Dynamic_DC_CLResControlMode;
 
 SCENARIO("DC charge loop state handling") {
 
     const auto evse_id = std::string("everest se");
-    const std::vector<message_20::ServiceCategory> supported_energy_services = {message_20::ServiceCategory::DC,
-                                                                                message_20::ServiceCategory::DC_BPT};
+    const std::vector<dt::ServiceCategory> supported_energy_services = {dt::ServiceCategory::DC,
+                                                                        dt::ServiceCategory::DC_BPT};
     const auto cert_install{false};
-    const std::vector<message_20::Authorization> auth_services = {message_20::Authorization::EIM};
+    const std::vector<dt::Authorization> auth_services = {dt::Authorization::EIM};
 
     d20::DcTransferLimits dc_limits;
     dc_limits.charge_limits.power.max = {22, 3};
@@ -39,9 +41,9 @@ SCENARIO("DC charge loop state handling") {
     discharge_limits.current.max = {30, 0};
 
     const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
-        {message_20::ControlMode::Scheduled, message_20::MobilityNeedsMode::ProvidedByEvcc},
-        {message_20::ControlMode::Dynamic, message_20::MobilityNeedsMode::ProvidedByEvcc},
-        {message_20::ControlMode::Dynamic, message_20::MobilityNeedsMode::ProvidedBySecc}};
+        {dt::ControlMode::Scheduled, dt::MobilityNeedsMode::ProvidedByEvcc},
+        {dt::ControlMode::Dynamic, dt::MobilityNeedsMode::ProvidedByEvcc},
+        {dt::ControlMode::Dynamic, dt::MobilityNeedsMode::ProvidedBySecc}};
 
     const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services, cert_install,
                                           dc_limits, control_mobility_modes};
@@ -65,9 +67,9 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 0.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 0.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 0.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 0.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
@@ -78,9 +80,9 @@ SCENARIO("DC charge loop state handling") {
     GIVEN("Bad case - false energy mode") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing,
-            message_20::BptChannel::Unified, message_20::GeneratorMode::GridFollowing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing, dt::BptChannel::Unified,
+            dt::GeneratorMode::GridFollowing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -99,9 +101,9 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: FAILED, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 0.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 0.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 0.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 0.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
@@ -111,9 +113,9 @@ SCENARIO("DC charge loop state handling") {
 
     GIVEN("Bad case - false control mode") {
 
-        d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+        d20::SelectedServiceParameters service_parameters =
+            d20::SelectedServiceParameters(dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+                                           dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -132,9 +134,9 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: FAILED, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 0.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 0.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 0.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 0.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
@@ -145,8 +147,8 @@ SCENARIO("DC charge loop state handling") {
     GIVEN("Good case - DC scheduled mode") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -165,31 +167,30 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Scheduled_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Scheduled_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_charge_power.value_or(message_20::RationalNumber{0, 0})) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.min_charge_power.value_or(message_20::RationalNumber{0, 0})) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_charge_current.value_or(message_20::RationalNumber{0, 0})) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_voltage.value_or(message_20::RationalNumber{0, 0})) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current.value_or(dt::RationalNumber{0, 0})) ==
+                    250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage.value_or(dt::RationalNumber{0, 0})) == 900.0f);
         }
     }
 
     GIVEN("Good case - DC_BPT scheduled mode") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -200,7 +201,7 @@ SCENARIO("DC charge loop state handling") {
         auto& req_control_mode = req.control_mode.emplace<Scheduled_BPT_DC_Req>();
         req_control_mode.target_current = {40, 0};
         req_control_mode.target_voltage = {400, 0};
-        req_control_mode.max_discharge_power.emplace<message_20::RationalNumber>({11, 3});
+        req_control_mode.max_discharge_power.emplace<dt::RationalNumber>({11, 3});
 
         req.meter_info_requested = false;
         req.present_voltage = {330, 0};
@@ -209,36 +210,35 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Scheduled_BPT_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Scheduled_BPT_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_charge_power.value_or(message_20::RationalNumber{0, 0})) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.min_charge_power.value_or(message_20::RationalNumber{0, 0})) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_charge_current.value_or(message_20::RationalNumber{0, 0})) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_voltage.value_or(message_20::RationalNumber{0, 0})) == 900.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_discharge_power.value_or(message_20::RationalNumber{0, 0})) == 11000.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.min_discharge_power.value_or(message_20::RationalNumber{0, 0})) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(
-                        res_control_mode.max_discharge_current.value_or(message_20::RationalNumber{0, 0})) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current.value_or(dt::RationalNumber{0, 0})) ==
+                    250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage.value_or(dt::RationalNumber{0, 0})) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_discharge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    11000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_discharge_power.value_or(dt::RationalNumber{0, 0})) ==
+                    10.0f);
+            REQUIRE(dt::from_RationalNumber(
+                        res_control_mode.max_discharge_current.value_or(dt::RationalNumber{0, 0})) == 30.0f);
         }
     }
 
     GIVEN("Good case - DC dynamic mode") {
-        d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+        d20::SelectedServiceParameters service_parameters =
+            d20::SelectedServiceParameters(dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+                                           dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -263,27 +263,27 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Dynamic_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Dynamic_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
         }
     }
 
     GIVEN("Good case - DC_BPT dynamic mode") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -311,29 +311,29 @@ SCENARIO("DC charge loop state handling") {
                                                     d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Dynamic_BPT_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Dynamic_BPT_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_discharge_power) == 11000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_discharge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_discharge_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_discharge_power) == 11000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_discharge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_discharge_current) == 30.0f);
         }
     }
 
     GIVEN("Good case - DC dynamic mode, mobility_needs_mode = 2") {
-        d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedBySecc, message_20::Pricing::NoPricing);
+        d20::SelectedServiceParameters service_parameters =
+            d20::SelectedServiceParameters(dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+                                           dt::MobilityNeedsMode::ProvidedBySecc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -360,19 +360,19 @@ SCENARIO("DC charge loop state handling") {
             d20::state::handle_request(req, session, 330, 30, false, evse_setup.dc_limits, dynamic_parameters);
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Dynamic_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Dynamic_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
 
             REQUIRE(res_control_mode.departure_time.value_or(0) >= 59);
             REQUIRE(res_control_mode.target_soc.value_or(0) == 95);
@@ -382,8 +382,8 @@ SCENARIO("DC charge loop state handling") {
 
     GIVEN("Good case - DC_BPT dynamic mode, mobility_needs_mode = 2") {
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedBySecc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+            dt::MobilityNeedsMode::ProvidedBySecc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -413,22 +413,22 @@ SCENARIO("DC charge loop state handling") {
             d20::state::handle_request(req, session, 330, 30, false, evse_setup.dc_limits, dynamic_parameters);
 
         THEN("ResponseCode: OK, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(message_20::from_RationalNumber(res.present_current) == 30.0f);
-            REQUIRE(message_20::from_RationalNumber(res.present_voltage) == 330.0f);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(dt::from_RationalNumber(res.present_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res.present_voltage) == 330.0f);
             REQUIRE(res.current_limit_achieved == false);
             REQUIRE(res.power_limit_achieved == false);
             REQUIRE(res.voltage_limit_achieved == false);
 
             REQUIRE(std::holds_alternative<Dynamic_BPT_DC_Res>(res.control_mode));
             const auto& res_control_mode = std::get<Dynamic_BPT_DC_Res>(res.control_mode);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_discharge_power) == 11000.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.min_discharge_power) == 10.0f);
-            REQUIRE(message_20::from_RationalNumber(res_control_mode.max_discharge_current) == 30.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_power) == 22000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_charge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_charge_current) == 250.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_voltage) == 900.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_discharge_power) == 11000.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.min_discharge_power) == 10.0f);
+            REQUIRE(dt::from_RationalNumber(res_control_mode.max_discharge_current) == 30.0f);
 
             REQUIRE(res_control_mode.departure_time.value_or(0) >= 39);
             REQUIRE(res_control_mode.minimum_soc.value_or(0) == 95);

--- a/test/iso15118/states/dc_charge_parameter_discovery.cpp
+++ b/test/iso15118/states/dc_charge_parameter_discovery.cpp
@@ -6,21 +6,23 @@
 
 using namespace iso15118;
 
-using DC_ModeReq = message_20::DC_ChargeParameterDiscoveryRequest::DC_CPDReqEnergyTransferMode;
-using BPT_DC_ModeReq = message_20::DC_ChargeParameterDiscoveryRequest::BPT_DC_CPDReqEnergyTransferMode;
+namespace dt = message_20::datatypes;
 
-using DC_ModeRes = message_20::DC_ChargeParameterDiscoveryResponse::DC_CPDResEnergyTransferMode;
-using BPT_DC_ModeRes = message_20::DC_ChargeParameterDiscoveryResponse::BPT_DC_CPDResEnergyTransferMode;
+using DC_ModeReq = message_20::datatypes::DC_CPDReqEnergyTransferMode;
+using BPT_DC_ModeReq = message_20::datatypes::BPT_DC_CPDReqEnergyTransferMode;
+
+using DC_ModeRes = message_20::datatypes::DC_CPDResEnergyTransferMode;
+using BPT_DC_ModeRes = message_20::datatypes::BPT_DC_CPDResEnergyTransferMode;
 
 SCENARIO("DC charge parameter discovery state handling") {
 
     const auto evse_id = std::string("everest se");
-    const std::vector<message_20::ServiceCategory> supported_energy_services = {message_20::ServiceCategory::DC};
+    const std::vector<dt::ServiceCategory> supported_energy_services = {dt::ServiceCategory::DC};
     const auto cert_install{false};
-    const std::vector<message_20::Authorization> auth_services = {message_20::Authorization::EIM};
+    const std::vector<dt::Authorization> auth_services = {dt::Authorization::EIM};
     const d20::DcTransferLimits dc_limits;
     const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
-        {message_20::ControlMode::Scheduled, message_20::MobilityNeedsMode::ProvidedByEvcc}};
+        {dt::ControlMode::Scheduled, dt::MobilityNeedsMode::ProvidedByEvcc}};
 
     const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services, cert_install,
                                           dc_limits, control_mobility_modes};
@@ -44,7 +46,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, d20::Session(), evse_setup.dc_limits);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
 
             REQUIRE(std::holds_alternative<DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeRes>(res.transfer_mode);
@@ -67,9 +69,9 @@ SCENARIO("DC charge parameter discovery state handling") {
     GIVEN("Bad Case: e.g. dc transfer mod instead of dc_bpt transfer mod - FAILED_WrongChargeParameter") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing,
-            message_20::BptChannel::Unified, message_20::GeneratorMode::GridFollowing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing, dt::BptChannel::Unified,
+            dt::GeneratorMode::GridFollowing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -88,7 +90,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, session, evse_setup.dc_limits);
 
         THEN("ResponseCode: FAILED_WrongChargeParameter, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_WrongChargeParameter);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_WrongChargeParameter);
 
             REQUIRE(std::holds_alternative<DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeRes>(res.transfer_mode);
@@ -111,8 +113,8 @@ SCENARIO("DC charge parameter discovery state handling") {
     GIVEN("Bad Case: e.g. DC_BPT transfer mod instead of dc transfer mod - FAILED_WrongChargeParameter") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -135,7 +137,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, session, evse_setup.dc_limits);
 
         THEN("ResponseCode: FAILED_WrongChargeParameter, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_WrongChargeParameter);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_WrongChargeParameter);
 
             REQUIRE(std::holds_alternative<DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeRes>(res.transfer_mode);
@@ -158,8 +160,8 @@ SCENARIO("DC charge parameter discovery state handling") {
     GIVEN("Good Case: DC") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -167,7 +169,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         dc_limits.charge_limits.power.max = {22, 3};
         dc_limits.charge_limits.current.max = {25, 0};
         dc_limits.voltage.max = {900, 0};
-        message_20::RationalNumber power_ramp_limit = {20, 0};
+        dt::RationalNumber power_ramp_limit = {20, 0};
         dc_limits.power_ramp_limit.emplace<>(power_ramp_limit);
 
         message_20::DC_ChargeParameterDiscoveryRequest req;
@@ -185,7 +187,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, session, dc_limits);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
 
             REQUIRE(std::holds_alternative<DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeRes>(res.transfer_mode);
@@ -210,9 +212,9 @@ SCENARIO("DC charge parameter discovery state handling") {
     GIVEN("Good Case: DC_BPT") {
 
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing,
-            message_20::BptChannel::Unified, message_20::GeneratorMode::GridFollowing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing, dt::BptChannel::Unified,
+            dt::GeneratorMode::GridFollowing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -244,7 +246,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, session, dc_limits);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
 
             REQUIRE(std::holds_alternative<BPT_DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<BPT_DC_ModeRes>(res.transfer_mode);
@@ -274,9 +276,9 @@ SCENARIO("DC charge parameter discovery state handling") {
 
     GIVEN("Bad Case: Provided DC charge limits but the ev wants bpt charge parameter - FAILED") {
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC_BPT, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing,
-            message_20::BptChannel::Unified, message_20::GeneratorMode::GridFollowing);
+            dt::ServiceCategory::DC_BPT, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing, dt::BptChannel::Unified,
+            dt::GeneratorMode::GridFollowing);
 
         d20::Session session = d20::Session(service_parameters);
 
@@ -304,7 +306,7 @@ SCENARIO("DC charge parameter discovery state handling") {
         const auto res = d20::state::handle_request(req, session, dc_limits);
 
         THEN("ResponseCode: FAILED, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED);
 
             REQUIRE(std::holds_alternative<DC_ModeRes>(res.transfer_mode));
             const auto& transfer_mode = std::get<DC_ModeRes>(res.transfer_mode);

--- a/test/iso15118/states/dc_pre_charge.cpp
+++ b/test/iso15118/states/dc_pre_charge.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("DC Pre charge state handling") {
 
     GIVEN("Bad case - Unknown session") {
@@ -16,7 +18,7 @@ SCENARIO("DC Pre charge state handling") {
 
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.processing = message_20::Processing::Ongoing;
+        req.processing = dt::Processing::Ongoing;
         req.present_voltage = {0, 0};
         req.target_voltage = {400, 0};
 
@@ -25,7 +27,7 @@ SCENARIO("DC Pre charge state handling") {
         const auto res = d20::state::handle_request(req, d20::Session(), present_voltage);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
             REQUIRE(res.present_voltage.value == 0);
             REQUIRE(res.present_voltage.exponent == 0);
         }
@@ -38,7 +40,7 @@ SCENARIO("DC Pre charge state handling") {
 
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.processing = message_20::Processing::Ongoing;
+        req.processing = dt::Processing::Ongoing;
         req.present_voltage = {0, 0};
         req.target_voltage = {400, 0};
 
@@ -47,7 +49,7 @@ SCENARIO("DC Pre charge state handling") {
         const auto res = d20::state::handle_request(req, session, present_voltage);
 
         THEN("ResponseCode: OK, present_voltage should be 400.1V") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.present_voltage.value == 4001);
             REQUIRE(res.present_voltage.exponent == -1);
         }

--- a/test/iso15118/states/dc_welding_detection.cpp
+++ b/test/iso15118/states/dc_welding_detection.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("DC Welding Detection state handling") {
 
     GIVEN("Bad case - Unknown session") {
@@ -15,14 +17,14 @@ SCENARIO("DC Welding Detection state handling") {
         message_20::DC_WeldingDetectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.processing = message_20::Processing::Ongoing;
+        req.processing = dt::Processing::Ongoing;
 
         const float present_voltage = 0.1;
 
         const auto res = d20::state::handle_request(req, d20::Session(), present_voltage);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
             REQUIRE(res.present_voltage.value == 0);
             REQUIRE(res.present_voltage.exponent == 0);
         }
@@ -35,14 +37,14 @@ SCENARIO("DC Welding Detection state handling") {
         message_20::DC_WeldingDetectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.processing = message_20::Processing::Ongoing;
+        req.processing = dt::Processing::Ongoing;
 
         const float present_voltage = 200;
 
         const auto res = d20::state::handle_request(req, session, present_voltage);
 
         THEN("ResponseCode: OK, present_voltage should be 200V") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.present_voltage.value == 2000);
             REQUIRE(res.present_voltage.exponent == -1);
         }

--- a/test/iso15118/states/power_delivery.cpp
+++ b/test/iso15118/states/power_delivery.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Power delivery state handling") {
     GIVEN("Bad case - Unknown session") {
         d20::Session session = d20::Session();
@@ -14,13 +16,13 @@ SCENARIO("Power delivery state handling") {
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.processing = message_20::Processing::Ongoing;
-        req.charge_progress = message_20::PowerDeliveryRequest::Progress::Start;
+        req.processing = dt::Processing::Ongoing;
+        req.charge_progress = dt::Progress::Start;
 
         const auto res = d20::state::handle_request(req, d20::Session());
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
             REQUIRE(res.status.has_value() == false);
         }
     }
@@ -31,15 +33,15 @@ SCENARIO("Power delivery state handling") {
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        req.processing = message_20::Processing::Ongoing;
-        req.charge_progress = message_20::PowerDeliveryRequest::Progress::Standby;
+        req.processing = dt::Processing::Ongoing;
+        req.charge_progress = dt::Progress::Standby;
 
         const auto res = d20::state::handle_request(req, session);
 
         // Right now standby ist not supported
 
         THEN("ResponseCode: WARNING_StandbyNotAllowed, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::WARNING_StandbyNotAllowed);
+            REQUIRE(res.response_code == dt::ResponseCode::WARNING_StandbyNotAllowed);
             REQUIRE(res.status.has_value() == false);
         }
     }

--- a/test/iso15118/states/schedule_exchange.cpp
+++ b/test/iso15118/states/schedule_exchange.cpp
@@ -6,12 +6,14 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Schedule Exchange state handling") {
 
-    using Scheduled_ModeReq = message_20::ScheduleExchangeRequest::Scheduled_SEReqControlMode;
-    using Scheduled_ModeRes = message_20::ScheduleExchangeResponse::Scheduled_SEResControlMode;
-    using Dynamic_ModeReq = message_20::ScheduleExchangeRequest::Dynamic_SEReqControlMode;
-    using Dynamic_ModeRes = message_20::ScheduleExchangeResponse::Dynamic_SEResControlMode;
+    using Scheduled_ModeReq = message_20::datatypes::Scheduled_SEReqControlMode;
+    using Scheduled_ModeRes = message_20::datatypes::Scheduled_SEResControlMode;
+    using Dynamic_ModeReq = message_20::datatypes::Dynamic_SEReqControlMode;
+    using Dynamic_ModeRes = message_20::datatypes::Dynamic_SEResControlMode;
 
     GIVEN("Bad case - Unknown session") {
 
@@ -23,14 +25,14 @@ SCENARIO("Schedule Exchange state handling") {
 
         req.control_mode.emplace<Scheduled_ModeReq>();
 
-        message_20::RationalNumber max_power = {0, 0};
+        dt::RationalNumber max_power = {0, 0};
 
         const auto res = d20::state::handle_request(req, d20::Session(), max_power, d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
 
-            REQUIRE(res.processing == message_20::Processing::Finished);
+            REQUIRE(res.processing == dt::Processing::Finished);
 
             REQUIRE(std::holds_alternative<Dynamic_ModeRes>(res.control_mode) == true);
             const auto& res_control_mode = std::get<Dynamic_ModeRes>(res.control_mode);
@@ -40,8 +42,8 @@ SCENARIO("Schedule Exchange state handling") {
 
     GIVEN("Bad case - False control mode") {
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         auto session = d20::Session(service_parameters);
 
@@ -51,14 +53,14 @@ SCENARIO("Schedule Exchange state handling") {
 
         req.control_mode.emplace<Dynamic_ModeReq>();
 
-        message_20::RationalNumber max_power = {0, 0};
+        dt::RationalNumber max_power = {0, 0};
 
         const auto res = d20::state::handle_request(req, session, max_power, d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: FAILED, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED);
 
-            REQUIRE(res.processing == message_20::Processing::Finished);
+            REQUIRE(res.processing == dt::Processing::Finished);
 
             REQUIRE(std::holds_alternative<Dynamic_ModeRes>(res.control_mode) == true);
             const auto& res_control_mode = std::get<Dynamic_ModeRes>(res.control_mode);
@@ -68,8 +70,8 @@ SCENARIO("Schedule Exchange state handling") {
 
     GIVEN("Good case - Scheduled Mode") {
         d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+            dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         auto session = d20::Session(service_parameters);
 
@@ -79,14 +81,14 @@ SCENARIO("Schedule Exchange state handling") {
 
         req.control_mode.emplace<Scheduled_ModeReq>();
 
-        message_20::RationalNumber max_power = {22, 3};
+        dt::RationalNumber max_power = {22, 3};
 
         const auto res = d20::state::handle_request(req, session, max_power, d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
 
-            REQUIRE(res.processing == message_20::Processing::Finished);
+            REQUIRE(res.processing == dt::Processing::Finished);
 
             REQUIRE(std::holds_alternative<Scheduled_ModeRes>(res.control_mode) == true);
             const auto& res_control_mode = std::get<Scheduled_ModeRes>(res.control_mode);
@@ -94,15 +96,15 @@ SCENARIO("Schedule Exchange state handling") {
             REQUIRE(res_control_mode.schedule_tuple.size() == 1);
             const auto& schedule_tuple = res_control_mode.schedule_tuple[0];
 
-            REQUIRE(message_20::from_RationalNumber(
-                        schedule_tuple.charging_schedule.power_schedule.entries.at(0).power) == 22000);
+            REQUIRE(dt::from_RationalNumber(schedule_tuple.charging_schedule.power_schedule.entries.at(0).power) ==
+                    22000);
         }
     }
 
     GIVEN("Good case - Dynamic Mode") {
-        d20::SelectedServiceParameters service_parameters = d20::SelectedServiceParameters(
-            message_20::ServiceCategory::DC, message_20::DcConnector::Extended, message_20::ControlMode::Dynamic,
-            message_20::MobilityNeedsMode::ProvidedByEvcc, message_20::Pricing::NoPricing);
+        d20::SelectedServiceParameters service_parameters =
+            d20::SelectedServiceParameters(dt::ServiceCategory::DC, dt::DcConnector::Extended, dt::ControlMode::Dynamic,
+                                           dt::MobilityNeedsMode::ProvidedByEvcc, dt::Pricing::NoPricing);
 
         auto session = d20::Session(service_parameters);
 
@@ -112,13 +114,13 @@ SCENARIO("Schedule Exchange state handling") {
 
         req.control_mode.emplace<Dynamic_ModeReq>();
 
-        message_20::RationalNumber max_power = {22, 3};
+        dt::RationalNumber max_power = {22, 3};
 
         const auto res = d20::state::handle_request(req, session, max_power, d20::UpdateDynamicModeParameters());
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.processing == message_20::Processing::Finished);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.processing == dt::Processing::Finished);
 
             REQUIRE(std::holds_alternative<Dynamic_ModeRes>(res.control_mode) == true);
         }

--- a/test/iso15118/states/service_detail.cpp
+++ b/test/iso15118/states/service_detail.cpp
@@ -6,15 +6,17 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Service detail state handling") {
 
     const auto evse_id = std::string("everest se");
-    const std::vector<message_20::ServiceCategory> supported_energy_services = {message_20::ServiceCategory::DC};
+    const std::vector<dt::ServiceCategory> supported_energy_services = {dt::ServiceCategory::DC};
     const auto cert_install{false};
-    const std::vector<message_20::Authorization> auth_services = {message_20::Authorization::EIM};
+    const std::vector<dt::Authorization> auth_services = {dt::Authorization::EIM};
     const d20::DcTransferLimits dc_limits;
     const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
-        {message_20::ControlMode::Scheduled, message_20::MobilityNeedsMode::ProvidedByEvcc}};
+        {dt::ControlMode::Scheduled, dt::MobilityNeedsMode::ProvidedByEvcc}};
 
     const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services, cert_install,
                                           dc_limits, control_mobility_modes};
@@ -26,7 +28,7 @@ SCENARIO("Service detail state handling") {
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::DC;
+        req.service = dt::ServiceCategory::DC;
 
         session = d20::Session();
         const auto session_config = d20::SessionConfig(evse_setup);
@@ -34,8 +36,8 @@ SCENARIO("Service detail state handling") {
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
-            REQUIRE(res.service == message_20::ServiceCategory::DC);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.service == dt::ServiceCategory::DC);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameter = res.service_parameter_list[0];
             REQUIRE(parameter.id == 0);
@@ -44,27 +46,27 @@ SCENARIO("Service detail state handling") {
             REQUIRE(std::holds_alternative<int32_t>(parameter.parameter[0].value));
 
             const auto& connector = std::get<int32_t>(parameter.parameter[0].value);
-            REQUIRE(static_cast<message_20::DcConnector>(connector) == message_20::DcConnector::Core);
+            REQUIRE(static_cast<dt::DcConnector>(connector) == dt::DcConnector::Core);
         }
     }
 
     GIVEN("Bad Case - FAILED_ServiceIDInvalid") {
 
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC_BPT};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC_BPT};
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::AC;
+        req.service = dt::ServiceCategory::AC;
 
         const auto session_config = d20::SessionConfig(evse_setup);
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: FAILED_ServiceIDInvalid, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_ServiceIDInvalid);
-            REQUIRE(res.service == message_20::ServiceCategory::DC);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_ServiceIDInvalid);
+            REQUIRE(res.service == dt::ServiceCategory::DC);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameter = res.service_parameter_list[0];
             REQUIRE(parameter.id == 0);
@@ -73,27 +75,27 @@ SCENARIO("Service detail state handling") {
             REQUIRE(std::holds_alternative<int32_t>(parameter.parameter[0].value));
 
             const auto& connector = std::get<int32_t>(parameter.parameter[0].value);
-            REQUIRE(static_cast<message_20::DcConnector>(connector) == message_20::DcConnector::Core);
+            REQUIRE(static_cast<dt::DcConnector>(connector) == dt::DcConnector::Core);
         }
     }
 
     GIVEN("Good Case - DC Service") {
 
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
 
         const auto session_config = d20::SessionConfig(evse_setup);
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::DC;
+        req.service = dt::ServiceCategory::DC;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::DC);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::DC);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameters = res.service_parameter_list[0];
             REQUIRE(parameters.id == 0);
@@ -120,20 +122,20 @@ SCENARIO("Service detail state handling") {
 
     GIVEN("Good Case - DC_BPT Service") {
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC_BPT};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC_BPT};
 
         const auto session_config = d20::SessionConfig(evse_setup);
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::DC_BPT;
+        req.service = dt::ServiceCategory::DC_BPT;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::DC_BPT);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::DC_BPT);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameters = res.service_parameter_list[0];
             REQUIRE(parameters.id == 0);
@@ -169,33 +171,33 @@ SCENARIO("Service detail state handling") {
     GIVEN("Good Case - 2x DC Services") {
 
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
 
         // FIXME(SL): Change evse_setup instead of session_config
         auto session_config = d20::SessionConfig(evse_setup);
         session_config.dc_parameter_list = {{
-                                                message_20::DcConnector::Extended,
-                                                message_20::ControlMode::Scheduled,
-                                                message_20::MobilityNeedsMode::ProvidedByEvcc,
-                                                message_20::Pricing::NoPricing,
+                                                dt::DcConnector::Extended,
+                                                dt::ControlMode::Scheduled,
+                                                dt::MobilityNeedsMode::ProvidedByEvcc,
+                                                dt::Pricing::NoPricing,
                                             },
                                             {
-                                                message_20::DcConnector::Extended,
-                                                message_20::ControlMode::Dynamic,
-                                                message_20::MobilityNeedsMode::ProvidedBySecc,
-                                                message_20::Pricing::NoPricing,
+                                                dt::DcConnector::Extended,
+                                                dt::ControlMode::Dynamic,
+                                                dt::MobilityNeedsMode::ProvidedBySecc,
+                                                dt::Pricing::NoPricing,
                                             }};
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::DC;
+        req.service = dt::ServiceCategory::DC;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::DC);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::DC);
             REQUIRE(res.service_parameter_list.size() == 2);
             auto& parameters_0 = res.service_parameter_list[0];
             REQUIRE(parameters_0.id == 0);
@@ -244,20 +246,20 @@ SCENARIO("Service detail state handling") {
     GIVEN("Bad Case - DC Service: Scheduled Mode: 1, MobilityNeedsMode: 2 change to 1") {
 
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
 
         const auto session_config = d20::SessionConfig(evse_setup);
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::DC;
+        req.service = dt::ServiceCategory::DC;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::DC);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::DC);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameters = res.service_parameter_list[0];
             REQUIRE(parameters.id == 0);
@@ -284,22 +286,22 @@ SCENARIO("Service detail state handling") {
 
     GIVEN("Good case - Internet service") {
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
-        session.offered_services.vas_services = {message_20::ServiceCategory::Internet};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
+        session.offered_services.vas_services = {dt::ServiceCategory::Internet};
 
         auto session_config = d20::SessionConfig(evse_setup);
-        session_config.internet_parameter_list = {{message_20::Protocol::Http, message_20::Port::Port80}};
+        session_config.internet_parameter_list = {{dt::Protocol::Http, dt::Port::Port80}};
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::Internet;
+        req.service = dt::ServiceCategory::Internet;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::Internet);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::Internet);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameters = res.service_parameter_list[0];
             REQUIRE(parameters.id == 3);
@@ -318,23 +320,23 @@ SCENARIO("Service detail state handling") {
 
     GIVEN("Good case - Parking status service") {
         d20::Session session = d20::Session();
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
-        session.offered_services.vas_services = {message_20::ServiceCategory::ParkingStatus};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
+        session.offered_services.vas_services = {dt::ServiceCategory::ParkingStatus};
 
         auto session_config = d20::SessionConfig(evse_setup);
         session_config.parking_parameter_list = {
-            {message_20::IntendedService::VehicleCheckIn, message_20::ParkingStatus::ManualExternal}};
+            {dt::IntendedService::VehicleCheckIn, dt::ParkingStatus::ManualExternal}};
 
         message_20::ServiceDetailRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.service = message_20::ServiceCategory::ParkingStatus;
+        req.service = dt::ServiceCategory::ParkingStatus;
 
         const auto res = d20::state::handle_request(req, session, session_config);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
-            REQUIRE(res.service == message_20::ServiceCategory::ParkingStatus);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.service == dt::ServiceCategory::ParkingStatus);
             REQUIRE(res.service_parameter_list.size() == 1);
             auto& parameters = res.service_parameter_list[0];
             REQUIRE(parameters.id == 0);

--- a/test/iso15118/states/service_discovery.cpp
+++ b/test/iso15118/states/service_discovery.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Service discovery state handling") {
 
     GIVEN("Bad Case - Unknown session") {
@@ -17,16 +19,16 @@ SCENARIO("Service discovery state handling") {
 
         session = d20::Session();
 
-        std::vector<message_20::ServiceCategory> energy_services = {message_20::ServiceCategory::DC};
+        std::vector<dt::ServiceCategory> energy_services = {dt::ServiceCategory::DC};
 
         const auto res = d20::state::handle_request(req, session, energy_services, {});
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
             REQUIRE(res.service_renegotiation_supported == false);
             REQUIRE(res.energy_transfer_service_list.size() == 1);
             REQUIRE(res.energy_transfer_service_list[0].free_service == false);
-            REQUIRE(res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::AC);
+            REQUIRE(res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::AC);
             REQUIRE(res.vas_list.has_value() == false);
         }
     }
@@ -39,21 +41,21 @@ SCENARIO("Service discovery state handling") {
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        std::vector<message_20::ServiceCategory> supported_energy_transfer_services = {
-            message_20::ServiceCategory::DC, message_20::ServiceCategory::DC_BPT};
+        std::vector<dt::ServiceCategory> supported_energy_transfer_services = {dt::ServiceCategory::DC,
+                                                                               dt::ServiceCategory::DC_BPT};
 
         const auto res = d20::state::handle_request(req, session, supported_energy_transfer_services, {});
 
         THEN("ResponseCode: OK, energy_transfer_service_list: DC & DC_WPT, vaslist: empty") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.service_renegotiation_supported == false);
             REQUIRE(res.energy_transfer_service_list.size() == 2);
             REQUIRE(res.energy_transfer_service_list[0].free_service == false);
-            REQUIRE((res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::DC ||
-                     res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::DC_BPT));
+            REQUIRE((res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::DC ||
+                     res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::DC_BPT));
             REQUIRE(res.energy_transfer_service_list[1].free_service == false);
-            REQUIRE((res.energy_transfer_service_list[1].service_id == message_20::ServiceCategory::DC ||
-                     res.energy_transfer_service_list[1].service_id == message_20::ServiceCategory::DC_BPT));
+            REQUIRE((res.energy_transfer_service_list[1].service_id == dt::ServiceCategory::DC ||
+                     res.energy_transfer_service_list[1].service_id == dt::ServiceCategory::DC_BPT));
             REQUIRE(res.vas_list.has_value() == false);
         }
     }
@@ -66,26 +68,26 @@ SCENARIO("Service discovery state handling") {
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
 
-        std::vector<message_20::ServiceCategory> supported_energy_transfer_services = {
-            message_20::ServiceCategory::DC, message_20::ServiceCategory::DC_BPT};
-        std::vector<message_20::ServiceCategory> supported_vas_services = {message_20::ServiceCategory::ParkingStatus};
+        std::vector<dt::ServiceCategory> supported_energy_transfer_services = {dt::ServiceCategory::DC,
+                                                                               dt::ServiceCategory::DC_BPT};
+        std::vector<dt::ServiceCategory> supported_vas_services = {dt::ServiceCategory::ParkingStatus};
 
         const auto res =
             d20::state::handle_request(req, session, supported_energy_transfer_services, supported_vas_services);
 
         THEN("ResponseCode: OK, energy_transfer_service_list: DC & DC_BPT, vaslist: ParkingStatus") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.service_renegotiation_supported == false);
             REQUIRE(res.energy_transfer_service_list.size() == 2);
             REQUIRE(res.energy_transfer_service_list[0].free_service == false);
-            REQUIRE((res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::DC ||
-                     res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::DC_BPT));
+            REQUIRE((res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::DC ||
+                     res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::DC_BPT));
             REQUIRE(res.energy_transfer_service_list[1].free_service == false);
-            REQUIRE((res.energy_transfer_service_list[1].service_id == message_20::ServiceCategory::DC ||
-                     res.energy_transfer_service_list[1].service_id == message_20::ServiceCategory::DC_BPT));
+            REQUIRE((res.energy_transfer_service_list[1].service_id == dt::ServiceCategory::DC ||
+                     res.energy_transfer_service_list[1].service_id == dt::ServiceCategory::DC_BPT));
             REQUIRE(res.vas_list.has_value() == true);
             REQUIRE(res.vas_list.value()[0].free_service == false);
-            REQUIRE(res.vas_list.value()[0].service_id == message_20::ServiceCategory::ParkingStatus);
+            REQUIRE(res.vas_list.value()[0].service_id == dt::ServiceCategory::ParkingStatus);
         }
     }
 
@@ -101,19 +103,19 @@ SCENARIO("Service discovery state handling") {
         supported_service_ids.push_back(2);
         supported_service_ids.push_back(65);
 
-        std::vector<message_20::ServiceCategory> supported_energy_transfer_services = {
-            message_20::ServiceCategory::DC, message_20::ServiceCategory::DC_BPT};
-        std::vector<message_20::ServiceCategory> supported_vas_services = {message_20::ServiceCategory::ParkingStatus};
+        std::vector<dt::ServiceCategory> supported_energy_transfer_services = {dt::ServiceCategory::DC,
+                                                                               dt::ServiceCategory::DC_BPT};
+        std::vector<dt::ServiceCategory> supported_vas_services = {dt::ServiceCategory::ParkingStatus};
 
         const auto res =
             d20::state::handle_request(req, session, supported_energy_transfer_services, supported_vas_services);
 
         THEN("ResponseCode: OK, energy_transfer_service_list: DC, vaslist: empty") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
             REQUIRE(res.service_renegotiation_supported == false);
             REQUIRE(res.energy_transfer_service_list.size() == 1);
             REQUIRE(res.energy_transfer_service_list[0].free_service == false);
-            REQUIRE(res.energy_transfer_service_list[0].service_id == message_20::ServiceCategory::DC);
+            REQUIRE(res.energy_transfer_service_list[0].service_id == dt::ServiceCategory::DC);
             REQUIRE(res.vas_list.has_value() == false);
         }
     }

--- a/test/iso15118/states/service_selection.cpp
+++ b/test/iso15118/states/service_selection.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Service selection state handling") {
     GIVEN("Bad case - Unknown session") {
 
@@ -14,7 +16,7 @@ SCENARIO("Service selection state handling") {
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC_BPT;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC_BPT;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
         session = d20::Session();
@@ -22,7 +24,7 @@ SCENARIO("Service selection state handling") {
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
         }
     }
 
@@ -30,24 +32,24 @@ SCENARIO("Service selection state handling") {
 
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 1;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: FAILED_ServiceSelectionInvalid, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_ServiceSelectionInvalid);
         }
     }
 
@@ -55,209 +57,207 @@ SCENARIO("Service selection state handling") {
 
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::AC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::AC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: FAILED_NoEnergyTransferServiceSelected, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_NoEnergyTransferServiceSelected);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_NoEnergyTransferServiceSelected);
         }
     }
 
     GIVEN("Good case") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
         }
     }
 
     GIVEN("Good case - Check if session variables is set") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
 
             const auto selected_services = session.get_selected_services();
-            REQUIRE(selected_services.selected_energy_service == message_20::ServiceCategory::DC);
-            REQUIRE(selected_services.selected_control_mode == message_20::ControlMode::Scheduled);
+            REQUIRE(selected_services.selected_energy_service == dt::ServiceCategory::DC);
+            REQUIRE(selected_services.selected_control_mode == dt::ControlMode::Scheduled);
         }
     }
 
     GIVEN("Good case - DC_BPT") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC_BPT};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC_BPT};
         session.offered_services.dc_bpt_parameter_list[0] = {{
-                                                                 message_20::DcConnector::Extended,
-                                                                 message_20::ControlMode::Scheduled,
-                                                                 message_20::MobilityNeedsMode::ProvidedByEvcc,
-                                                                 message_20::Pricing::NoPricing,
+                                                                 dt::DcConnector::Extended,
+                                                                 dt::ControlMode::Scheduled,
+                                                                 dt::MobilityNeedsMode::ProvidedByEvcc,
+                                                                 dt::Pricing::NoPricing,
                                                              },
-                                                             message_20::BptChannel::Unified,
-                                                             message_20::GeneratorMode::GridFollowing};
+                                                             dt::BptChannel::Unified,
+                                                             dt::GeneratorMode::GridFollowing};
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC_BPT;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC_BPT;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
 
             const auto selected_services = session.get_selected_services();
-            REQUIRE(selected_services.selected_energy_service == message_20::ServiceCategory::DC_BPT);
-            REQUIRE(selected_services.selected_control_mode == message_20::ControlMode::Scheduled);
+            REQUIRE(selected_services.selected_energy_service == dt::ServiceCategory::DC_BPT);
+            REQUIRE(selected_services.selected_control_mode == dt::ControlMode::Scheduled);
         }
     }
 
     GIVEN("Bad case: selected_vas_list false service id - FAILED_ServiceSelectionInvalid") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
-        session.offered_services.vas_services = {message_20::ServiceCategory::Internet};
+        session.offered_services.vas_services = {dt::ServiceCategory::Internet};
         session.offered_services.internet_parameter_list[0] = {
-            message_20::Protocol::Http,
-            message_20::Port::Port80,
+            dt::Protocol::Http,
+            dt::Port::Port80,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
-        req.selected_vas_list = {{message_20::ServiceCategory::ParkingStatus, 0}};
+        req.selected_vas_list = {{dt::ServiceCategory::ParkingStatus, 0}};
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: FAILED_ServiceSelectionInvalid, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_ServiceSelectionInvalid);
         }
     }
 
     GIVEN("Bad case: selected_vas_list false parameter set id - FAILED_ServiceSelectionInvalid") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
-        session.offered_services.vas_services = {message_20::ServiceCategory::Internet};
+        session.offered_services.vas_services = {dt::ServiceCategory::Internet};
         session.offered_services.internet_parameter_list[0] = {
-            message_20::Protocol::Http,
-            message_20::Port::Port80,
+            dt::Protocol::Http,
+            dt::Port::Port80,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
-        req.selected_vas_list = {{message_20::ServiceCategory::Internet, 1}};
+        req.selected_vas_list = {{dt::ServiceCategory::Internet, 1}};
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: FAILED_ServiceSelectionInvalid, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_ServiceSelectionInvalid);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_ServiceSelectionInvalid);
         }
     }
 
     GIVEN("Good case - DC & Internet & Parking") {
         d20::Session session = d20::Session();
 
-        session.offered_services.energy_services = {message_20::ServiceCategory::DC};
+        session.offered_services.energy_services = {dt::ServiceCategory::DC};
         session.offered_services.dc_parameter_list[0] = {
-            message_20::DcConnector::Extended,
-            message_20::ControlMode::Scheduled,
-            message_20::MobilityNeedsMode::ProvidedByEvcc,
-            message_20::Pricing::NoPricing,
+            dt::DcConnector::Extended,
+            dt::ControlMode::Scheduled,
+            dt::MobilityNeedsMode::ProvidedByEvcc,
+            dt::Pricing::NoPricing,
         };
 
-        session.offered_services.vas_services = {message_20::ServiceCategory::Internet,
-                                                 message_20::ServiceCategory::ParkingStatus};
+        session.offered_services.vas_services = {dt::ServiceCategory::Internet, dt::ServiceCategory::ParkingStatus};
         session.offered_services.internet_parameter_list[0] = {
-            message_20::Protocol::Http,
-            message_20::Port::Port80,
+            dt::Protocol::Http,
+            dt::Port::Port80,
         };
 
         session.offered_services.parking_parameter_list[0] = {
-            message_20::IntendedService::VehicleCheckIn,
-            message_20::ParkingStatus::ManualExternal,
+            dt::IntendedService::VehicleCheckIn,
+            dt::ParkingStatus::ManualExternal,
         };
 
         message_20::ServiceSelectionRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.selected_energy_transfer_service.service_id = message_20::ServiceCategory::DC;
+        req.selected_energy_transfer_service.service_id = dt::ServiceCategory::DC;
         req.selected_energy_transfer_service.parameter_set_id = 0;
 
-        req.selected_vas_list = {{message_20::ServiceCategory::Internet, 0},
-                                 {message_20::ServiceCategory::ParkingStatus, 0}};
+        req.selected_vas_list = {{dt::ServiceCategory::Internet, 0}, {dt::ServiceCategory::ParkingStatus, 0}};
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
         }
     }
 

--- a/test/iso15118/states/session_stop.cpp
+++ b/test/iso15118/states/session_stop.cpp
@@ -6,6 +6,8 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
 SCENARIO("Session Stop state handling") {
 
     GIVEN("Bad case - Unknown session") {
@@ -15,12 +17,12 @@ SCENARIO("Session Stop state handling") {
         message_20::SessionStopRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.charging_session = message_20::ChargingSession::Terminate;
+        req.charging_session = dt::ChargingSession::Terminate;
 
         const auto res = d20::state::handle_request(req, d20::Session());
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
         }
     }
 
@@ -31,12 +33,12 @@ SCENARIO("Session Stop state handling") {
         message_20::SessionStopRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.charging_session = message_20::ChargingSession::Terminate;
+        req.charging_session = dt::ChargingSession::Terminate;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::OK);
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
         }
     }
 
@@ -48,12 +50,12 @@ SCENARIO("Session Stop state handling") {
         message_20::SessionStopRequest req;
         req.header.session_id = session.get_id();
         req.header.timestamp = 1691411798;
-        req.charging_session = message_20::ChargingSession::ServiceRenegotiation;
+        req.charging_session = dt::ChargingSession::ServiceRenegotiation;
 
         const auto res = d20::state::handle_request(req, session);
 
         THEN("ResponseCode: OK") {
-            REQUIRE(res.response_code == message_20::ResponseCode::FAILED_NoServiceRenegotiationSupported);
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_NoServiceRenegotiationSupported);
         }
     }
 


### PR DESCRIPTION
## Describe your changes
The refactoring is based more on the ISO15118-20 schemas. Each cpp iso data type should match the respective xsd iso data type.

Struct definitions within the ISO message structs were also moved to the datatype namespace. This makes the code readable and more usable.

Each ISO data type can now be found under the `message_20::datatype` namespace.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

