### PR TITLE
Fixing compiler warnings for arm-poky-linux-gnueabi-g++

### DIFF
--- a/include/iso15118/message/dc_charge_loop.hpp
+++ b/include/iso15118/message/dc_charge_loop.hpp
@@ -94,9 +94,9 @@ struct DC_ChargeLoopResponse {
 
     RationalNumber present_current;
     RationalNumber present_voltage;
-    bool power_limit_achieved;
-    bool current_limit_achieved;
-    bool voltage_limit_achieved;
+    bool power_limit_achieved{false};
+    bool current_limit_achieved{false};
+    bool voltage_limit_achieved{false};
 
     std::variant<Scheduled_DC_CLResControlMode, BPT_Scheduled_DC_CLResControlMode, Dynamic_DC_CLResControlMode,
                  BPT_Dynamic_DC_CLResControlMode>

--- a/src/iso15118/d20/state/authorization.cpp
+++ b/src/iso15118/d20/state/authorization.cpp
@@ -36,7 +36,7 @@ message_20::AuthorizationResponse handle_request(const message_20::Authorization
             res, message_20::ResponseCode::WARNING_AuthorizationSelectionInvalid); // [V2G20-2226] Handling if warning
     }
 
-    message_20::ResponseCode response_code;
+    auto response_code = message_20::ResponseCode::OK;
 
     switch (req.selected_authorization_service) {
     case message_20::Authorization::EIM:


### PR DESCRIPTION
## Describe your changes
Some variables were not initialized correctly.

## Issue ticket number and link
`arm-poky-linux-gnueabi-g++` has issued a few warnings

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

