### PR TITLE
Removing custom constructors from d20 message structs

### DIFF
--- a/include/iso15118/message/ac_charge_parameter_discovery.hpp
+++ b/include/iso15118/message/ac_charge_parameter_discovery.hpp
@@ -64,9 +64,8 @@ struct AC_ChargeParameterDiscoveryResponse {
     Header header;
     datatypes::ResponseCode response_code;
 
-    AC_ChargeParameterDiscoveryResponse() : transfer_mode(std::in_place_type<datatypes::AC_CPDResEnergyTransferMode>){};
-
-    std::variant<datatypes::AC_CPDResEnergyTransferMode, datatypes::BPT_AC_CPDResEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::AC_CPDResEnergyTransferMode, datatypes::BPT_AC_CPDResEnergyTransferMode> transfer_mode =
+        datatypes::AC_CPDResEnergyTransferMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/authorization.hpp
+++ b/include/iso15118/message/authorization.hpp
@@ -35,11 +35,9 @@ struct AuthorizationRequest {
 };
 
 struct AuthorizationResponse {
-    AuthorizationResponse() : evse_processing(datatypes::Processing::Finished){};
-
     Header header;
     datatypes::ResponseCode response_code;
-    datatypes::Processing evse_processing;
+    datatypes::Processing evse_processing{datatypes::Processing::Finished};
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/authorization_setup.hpp
+++ b/include/iso15118/message/authorization_setup.hpp
@@ -28,17 +28,13 @@ struct AuthorizationSetupRequest {
 };
 
 struct AuthorizationSetupResponse {
-    AuthorizationSetupResponse() :
-        authorization_services({datatypes::Authorization::EIM}),
-        certificate_installation_service(false),
-        authorization_mode(std::in_place_type<datatypes::EIM_ASResAuthorizationMode>){};
-
     Header header;
     datatypes::ResponseCode response_code;
 
-    std::vector<datatypes::Authorization> authorization_services;
-    bool certificate_installation_service;
-    std::variant<datatypes::EIM_ASResAuthorizationMode, datatypes::PnC_ASResAuthorizationMode> authorization_mode;
+    std::vector<datatypes::Authorization> authorization_services{{datatypes::Authorization::EIM}};
+    bool certificate_installation_service{false};
+    std::variant<datatypes::EIM_ASResAuthorizationMode, datatypes::PnC_ASResAuthorizationMode> authorization_mode =
+        datatypes::EIM_ASResAuthorizationMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_cable_check.hpp
+++ b/include/iso15118/message/dc_cable_check.hpp
@@ -11,13 +11,10 @@ struct DC_CableCheckRequest {
 };
 
 struct DC_CableCheckResponse {
-
-    DC_CableCheckResponse() : processing(datatypes::Processing::Ongoing){};
-
     Header header;
     datatypes::ResponseCode response_code;
 
-    datatypes::Processing processing;
+    datatypes::Processing processing{datatypes::Processing::Ongoing};
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_charge_loop.hpp
+++ b/include/iso15118/message/dc_charge_loop.hpp
@@ -104,9 +104,7 @@ struct DC_ChargeLoopResponse {
 
     std::variant<datatypes::Scheduled_DC_CLResControlMode, datatypes::BPT_Scheduled_DC_CLResControlMode,
                  datatypes::Dynamic_DC_CLResControlMode, datatypes::BPT_Dynamic_DC_CLResControlMode>
-        control_mode;
-
-    DC_ChargeLoopResponse() : control_mode(std::in_place_type<datatypes::Scheduled_DC_CLResControlMode>){};
+        control_mode = datatypes::Scheduled_DC_CLResControlMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/dc_charge_parameter_discovery.hpp
+++ b/include/iso15118/message/dc_charge_parameter_discovery.hpp
@@ -56,9 +56,8 @@ struct DC_ChargeParameterDiscoveryResponse {
     Header header;
     datatypes::ResponseCode response_code;
 
-    DC_ChargeParameterDiscoveryResponse() : transfer_mode(std::in_place_type<datatypes::DC_CPDResEnergyTransferMode>){};
-
-    std::variant<datatypes::DC_CPDResEnergyTransferMode, datatypes::BPT_DC_CPDResEnergyTransferMode> transfer_mode;
+    std::variant<datatypes::DC_CPDResEnergyTransferMode, datatypes::BPT_DC_CPDResEnergyTransferMode> transfer_mode =
+        datatypes::DC_CPDResEnergyTransferMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/schedule_exchange.hpp
+++ b/include/iso15118/message/schedule_exchange.hpp
@@ -193,16 +193,13 @@ struct ScheduleExchangeRequest {
 };
 
 struct ScheduleExchangeResponse {
-    ScheduleExchangeResponse() :
-        processing(datatypes::Processing::Finished),
-        control_mode(std::in_place_type<datatypes::Dynamic_SEResControlMode>){};
-
     Header header;
     datatypes::ResponseCode response_code;
-    datatypes::Processing processing;
+    datatypes::Processing processing{datatypes::Processing::Finished};
     std::optional<bool> go_to_pause;
 
-    std::variant<datatypes::Dynamic_SEResControlMode, datatypes::Scheduled_SEResControlMode> control_mode;
+    std::variant<datatypes::Dynamic_SEResControlMode, datatypes::Scheduled_SEResControlMode> control_mode =
+        datatypes::Dynamic_SEResControlMode();
 };
 
 } // namespace iso15118::message_20

--- a/include/iso15118/message/service_discovery.hpp
+++ b/include/iso15118/message/service_discovery.hpp
@@ -30,7 +30,6 @@ struct ServiceDiscoveryResponse {
     Header header;
     datatypes::ResponseCode response_code;
     bool service_renegotiation_supported = false;
-    // FIXME(sl): Adding constructor
     datatypes::ServiceList energy_transfer_service_list = {{
         datatypes::ServiceCategory::AC, // service_id
         false                           // free_service


### PR DESCRIPTION
## Describe your changes
The custom constructors have been replaced with default values.

## Issue ticket number and link
In PR #42 @a-w50 mentioned that the custom constructor should be removed and default values for variable members should be used instead. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

