### PR TITLE
refactor(gcovr): cmake simplification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,6 @@ message(STATUS "Building libiso15118 with the following compile options: ${ISO15
 
 if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TESTING) AND BUILD_TESTING)
     set(ISO15118_BUILD_TESTING ON)
-    evc_include(CodeCoverage)
-    append_coverage_compiler_flags()
 endif()
 
 # dependencies
@@ -56,25 +54,8 @@ add_subdirectory(input)
 add_subdirectory(src)
 
 if (ISO15118_BUILD_TESTING)
-    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE) # TODO(sl): Check if necessary
-
     include(CTest)
-    list(APPEND CMAKE_MODULE_PATH ${CPM_PACKAGE_catch2_SOURCE_DIR}/extras)
     add_subdirectory(test)
-
-    # FIXME(sl): Set gcovr correctly so that it finds the catch2 files. 
-    set(GCOVR_ADDITIONAL_ARGS "--gcov-ignore-errors=no_working_dir_found")
-    setup_target_for_coverage_gcovr_html(
-        NAME ${PROJECT_NAME}_gcovr_coverage
-        EXECUTABLE ctest
-        EXCLUDE "test/*" "build/*"
-    )
-
-    setup_target_for_coverage_gcovr_xml(
-        NAME ${PROJECT_NAME}_gcovr_coverage_xml
-        EXECUTABLE ctest
-        EXCLUDE "test/*" "build/*"
-    )
 endif()
 
 if (ISO15118_INSTALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,24 @@
 add_compile_options(${ISO15118_COMPILE_OPTIONS_WARNING})
+list(APPEND CMAKE_MODULE_PATH ${CPM_PACKAGE_catch2_SOURCE_DIR}/extras)
 
 add_subdirectory(exi)
 add_subdirectory(iso15118)
 add_subdirectory(v2gtp)
+
+
+#
+# code coverage specifics
+#
+
+evc_include(CodeCoverage)
+append_coverage_compiler_flags_to_target(iso15118)
+
+setup_target_for_coverage_gcovr_html(
+    NAME ${PROJECT_NAME}_gcovr_coverage
+    EXECUTABLE ctest
+)
+
+setup_target_for_coverage_gcovr_xml(
+    NAME ${PROJECT_NAME}_gcovr_coverage_xml
+    EXECUTABLE ctest
+)


### PR DESCRIPTION
- only add code coverage compiler flags to target iso15118 (this way exlcudes are not necessary and dir-not-found-errors are gone)
- move code coverage cmake logic into `tests/CMakeLists.txt` for better separation (and less bloat in main `CMakeLists.txt`)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

