### PR TITLE
Bump ci workflow version from fork

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   ci:
     name: Build, Lint and Test
-    uses: everest/everest-ci/.github/workflows/continuous_integration.yml@bugfix/ci-artifacts-on-forks
+    uses: everest/everest-ci/.github/workflows/continuous_integration.yml@v1.4.6
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   ci:
     name: Build, Lint and Test
-    uses: everest/everest-ci/.github/workflows/continuous_integration.yml@v1.4.3
+    uses: everest/everest-ci/.github/workflows/continuous_integration.yml@bugfix/ci-artifacts-on-forks
     permissions:
       contents: read
     secrets:


### PR DESCRIPTION
## Describe your changes

With everest-ci version v1.4.6 ci-artifacts aren't deployed anymore for PRs coming from forks.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

