### PR TITLE
Adding FetchContent for everest-cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,24 @@ project(iso15118
 	LANGUAGES CXX C
 )
 
-find_package(everest-cmake 0.1 REQUIRED
+find_package(everest-cmake 0.5
     PATHS ../everest-cmake
 )
 
 find_package(OpenSSL 3 REQUIRED)
+
+if (NOT everest-cmake_FOUND)
+    message(STATUS "Retrieving everest-cmake using FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        everest-cmake
+        GIT_REPOSITORY https://github.com/EVerest/everest-cmake.git
+        GIT_TAG        v0.5.0
+    )
+    FetchContent_MakeAvailable(everest-cmake)
+    set(everest-cmake_DIR "${everest-cmake_SOURCE_DIR}")
+    include("${everest-cmake_SOURCE_DIR}/everest-cmake-config.cmake")
+endif()
 
 # options
 option(${PROJECT_NAME}_BUILD_TESTING "Build unit tests, used if included as dependency" OFF)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,23 @@ ISO15118 support is distributed accross multiple repositories and modules in EVe
 Dependencies
 ------------
 
-To build this library you need [everest-cmake](https://github.com/EVerest/everest-cmake) checkout in the same directory as libiso15118.
+To build this library you need [everest-cmake](https://github.com/EVerest/everest-cmake) checkout in the same directory as libiso15118. If no `everest-cmake` is available, it is retrieved via FetchContent.
+
+For Debian GNU/Linux 12 you will need the following dependencies:
+
+```bash
+sudo apt update
+sudo apt install build-essential cmake libssl-dev
+```
+
+For Fedora 41+ you will need the following dependencies:
+
+```bash
+sudo dnf update
+sudo dnf install gcc gcc-c++ git make cmake openssl-devel 
+```
+
+OpenSSL version 3.0 or above is required. The build system `ninja` is optional. 
 
 Getting started
 ---------------


### PR DESCRIPTION
## Describe your changes
Adding an option to download everest-cmake automatically if `everest-cmake` is not provided.
Updating dependencies which should be installed to build libiso15118.

## Issue ticket number and link
Right now the library built only if `everest-cmake` was checkout in the same directory as `libiso15118`. It has often happened that users have forgotten to download everest-cmake. Or that it is an obstacle for them.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

