### PR TITLE
ServiceSelectionRequest: fix crash on optional array

### DIFF
--- a/src/iso15118/message/service_selection.cpp
+++ b/src/iso15118/message/service_selection.cpp
@@ -17,6 +17,7 @@ template <> void convert(const struct iso20_ServiceSelectionReqType& in, Service
     out.selected_energy_transfer_service.parameter_set_id = in.SelectedEnergyTransferService.ParameterSetID;
 
     if (in.SelectedVASList_isUsed == true) {
+        out.selected_vas_list.emplace(datatypes::SelectedServiceList({}));
         out.selected_vas_list.value().reserve(in.SelectedVASList.SelectedService.arrayLen);
         auto& vas_list_out = *out.selected_vas_list;
 


### PR DESCRIPTION
The optional array needs to be created before operating on it.

This fixes a potential crash with VAS in ServiceSelectionRequest.

Found by https://github.com/EVerest/libiso15118/issues/52

## Describe your changes

Create the optional array.

## Issue ticket number and link

https://github.com/EVerest/libiso15118/issues/52

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

