### PR TITLE
Small improvements (Codecoverage with clang, updating libiso version, etc.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(iso15118
-    VERSION 0.5.1
+    VERSION 0.6
     DESCRIPTION "iso15118 library suite"
 	LANGUAGES CXX C
 )
 
 find_package(everest-cmake 0.5
     PATHS ../everest-cmake
+    NO_DEFAULT_PATH
 )
 
 find_package(OpenSSL 3 REQUIRED)
@@ -18,7 +19,7 @@ if (NOT everest-cmake_FOUND)
     FetchContent_Declare(
         everest-cmake
         GIT_REPOSITORY https://github.com/EVerest/everest-cmake.git
-        GIT_TAG        v0.5.1
+        GIT_TAG        v0.5.3
     )
     FetchContent_MakeAvailable(everest-cmake)
     set(everest-cmake_DIR "${everest-cmake_SOURCE_DIR}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,19 +10,15 @@ add_subdirectory(v2gtp)
 # code coverage specifics
 #
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    evc_include(CodeCoverage)
-    append_coverage_compiler_flags_to_target(iso15118)
+evc_include(CodeCoverage)
+append_coverage_compiler_flags_to_target(iso15118)
 
-    setup_target_for_coverage_gcovr_html(
-        NAME ${PROJECT_NAME}_gcovr_coverage
-        EXECUTABLE ctest
-    )
+setup_target_for_coverage_gcovr_html(
+    NAME ${PROJECT_NAME}_gcovr_coverage
+    EXECUTABLE ctest
+)
 
-    setup_target_for_coverage_gcovr_xml(
-        NAME ${PROJECT_NAME}_gcovr_coverage_xml
-        EXECUTABLE ctest
-    )
-else()
-    message(WARNING "Code coverage is disabled when not building with gcc")
-endif()
+setup_target_for_coverage_gcovr_xml(
+    NAME ${PROJECT_NAME}_gcovr_coverage_xml
+    EXECUTABLE ctest
+)


### PR DESCRIPTION
## Describe your changes
- Codeverage works with clang
- Updating cmake libiso version
- Adding .cache to .gitignore

## Issue ticket number and link
Codecoverage did not work with clang. With some changes in everest-cmake now it works.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

