### PR TITLE
Adding an option to select custom protocol namespaces

### DIFF
--- a/include/iso15118/d20/config.hpp
+++ b/include/iso15118/d20/config.hpp
@@ -23,6 +23,7 @@ struct EvseSetupConfig {
     bool enable_certificate_install_service;
     d20::DcTransferLimits dc_limits;
     std::vector<ControlMobilityNeedsModes> control_mobility_modes;
+    std::optional<std::string> custom_protocol{std::nullopt};
 };
 
 // This should only have EVSE information
@@ -49,6 +50,8 @@ struct SessionConfig {
     DcTransferLimits dc_limits;
 
     std::vector<ControlMobilityNeedsModes> supported_control_mobility_modes;
+
+    std::optional<std::string> custom_protocol{std::nullopt};
 };
 
 } // namespace iso15118::d20

--- a/src/iso15118/d20/config.cpp
+++ b/src/iso15118/d20/config.cpp
@@ -110,7 +110,8 @@ SessionConfig::SessionConfig(EvseSetupConfig config) :
     authorization_services(std::move(config.authorization_services)),
     supported_energy_transfer_services(std::move(config.supported_energy_services)),
     dc_limits(std::move(config.dc_limits)),
-    supported_control_mobility_modes(std::move(config.control_mobility_modes)) {
+    supported_control_mobility_modes(std::move(config.control_mobility_modes)),
+    custom_protocol(std::move(config.custom_protocol)) {
 
     // TODO(SL): How to handle this probaly
     const auto is_bpt_service = [](dt::ServiceCategory service) {

--- a/src/iso15118/d20/state/supported_app_protocol.cpp
+++ b/src/iso15118/d20/state/supported_app_protocol.cpp
@@ -2,33 +2,43 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <iso15118/d20/state/supported_app_protocol.hpp>
 
+#include <map>
 #include <optional>
-#include <tuple>
 
 #include <iso15118/d20/state/session_setup.hpp>
 
 #include <iso15118/message/supported_app_protocol.hpp>
 
 #include <iso15118/detail/d20/context_helper.hpp>
+#include <iso15118/detail/helper.hpp>
 
 namespace iso15118::d20::state {
 
-std::tuple<message_20::SupportedAppProtocolResponse, std::optional<message_20::SupportedAppProtocol>>
-handle_request(const message_20::SupportedAppProtocolRequest& req) {
+constexpr auto ISO20_DC_NAMESPACE = "urn:iso:std:iso:15118:-20:DC";
+
+using ResponseCode = message_20::SupportedAppProtocolResponse::ResponseCode;
+
+message_20::SupportedAppProtocolResponse handle_request(const message_20::SupportedAppProtocolRequest& req,
+                                                        const std::optional<std::string>& custom_protocol_namespace) {
     message_20::SupportedAppProtocolResponse res;
-    std::optional<message_20::SupportedAppProtocol> selected_protocol{std::nullopt};
+
+    std::map<uint8_t, uint8_t> ev_supported_protocols{}; // key: priority, value: schema_id
 
     for (const auto& protocol : req.app_protocol) {
-        if (protocol.protocol_namespace.compare("urn:iso:std:iso:15118:-20:DC") == 0) {
-            res.schema_id = protocol.schema_id;
-            return {response_with_code(
-                        res, message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation),
-                    protocol};
+        if (protocol.protocol_namespace.compare(ISO20_DC_NAMESPACE) == 0) {
+            ev_supported_protocols[protocol.priority] = protocol.schema_id;
+        }
+        if (protocol.protocol_namespace.compare(custom_protocol_namespace.value_or("")) == 0) {
+            ev_supported_protocols[protocol.priority] = protocol.schema_id;
         }
     }
 
-    return {response_with_code(res, message_20::SupportedAppProtocolResponse::ResponseCode::Failed_NoNegotiation),
-            selected_protocol};
+    if (ev_supported_protocols.empty()) {
+        return response_with_code(res, ResponseCode::Failed_NoNegotiation);
+    }
+
+    res.schema_id = ev_supported_protocols.begin()->second; // [V2G20-167] Highest Prio: 1, Lowest Prio: 20
+    return response_with_code(res, ResponseCode::OK_SuccessfulNegotiation);
 }
 
 void SupportedAppProtocol::enter() {
@@ -44,23 +54,32 @@ Result SupportedAppProtocol::feed(Event ev) {
 
     if (const auto req = variant->get_if<message_20::SupportedAppProtocolRequest>()) {
 
-        const auto [res, selected_protocol] = handle_request(*req);
+        const auto res = handle_request(*req, m_ctx.session_config.custom_protocol);
         m_ctx.respond(res);
         m_ctx.ev_info.ev_supported_app_protocols = req->app_protocol;
 
-        if (selected_protocol.has_value()) {
-            std::string selected_protocol_string{""};
-            if (selected_protocol->protocol_namespace.compare("urn:iso:std:iso:15118:-20:DC") == 0) {
-                selected_protocol_string = "ISO15118-20:DC";
-            }
-            m_ctx.ev_info.selected_app_protocol = selected_protocol.value();
-            m_ctx.feedback.selected_protocol(selected_protocol_string);
-            return m_ctx.create_state<SessionSetup>();
+        if (res.response_code == ResponseCode::Failed_NoNegotiation) {
+            m_ctx.log("unsupported app protocol: [%s]",
+                      req->app_protocol.size() ? req->app_protocol[0].protocol_namespace.c_str() : "unknown");
+            return {};
         }
 
-        m_ctx.log("unsupported app protocol: [%s]",
-                  req->app_protocol.size() ? req->app_protocol[0].protocol_namespace.c_str() : "unknown");
-        return {};
+        for (const auto& protocol : req->app_protocol) {
+            if (protocol.schema_id == res.schema_id) {
+                m_ctx.ev_info.selected_app_protocol = protocol;
+
+                if (protocol.protocol_namespace.compare(ISO20_DC_NAMESPACE) == 0) {
+                    m_ctx.feedback.selected_protocol("ISO15118-20:DC");
+                }
+                if (protocol.protocol_namespace.compare(m_ctx.session_config.custom_protocol.value_or("")) == 0) {
+                    m_ctx.feedback.selected_protocol(m_ctx.session_config.custom_protocol.value());
+                    logf_warning(
+                        "EV and EVSE have agreed on a custom protocol namespace. Problems or aborts can occur in the "
+                        "following states!");
+                }
+            }
+        }
+        return m_ctx.create_state<SessionSetup>();
     } else {
         m_ctx.log("expected SupportedAppProtocolReq! But code type id: %d", variant->get_type());
 

--- a/test/iso15118/fsm/d20_transitions.cpp
+++ b/test/iso15118/fsm/d20_transitions.cpp
@@ -11,7 +11,7 @@
 
 using namespace iso15118;
 
-SCENARIO("ISO15118-20 state transitions") {
+SCENARIO("ISO15118-20 supported app protocol state transitions") {
 
     // Move to helper function?
     const auto evse_id = std::string("everest se");
@@ -22,9 +22,10 @@ SCENARIO("ISO15118-20 state transitions") {
     const d20::DcTransferLimits dc_limits;
     const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
         {message_20::datatypes::ControlMode::Scheduled, message_20::datatypes::MobilityNeedsMode::ProvidedByEvcc}};
+    const std::string custom_namespace = "urn:iso:std:iso:15118:-20:AABB";
 
-    const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services, cert_install,
-                                          dc_limits, control_mobility_modes};
+    const d20::EvseSetupConfig evse_setup{evse_id,   supported_energy_services, auth_services,   cert_install,
+                                          dc_limits, control_mobility_modes,    custom_namespace};
 
     std::optional<d20::PauseContext> pause_ctx{std::nullopt};
 
@@ -33,27 +34,149 @@ SCENARIO("ISO15118-20 state transitions") {
     auto state_helper = FsmStateHelper(d20::SessionConfig(evse_setup), pause_ctx, callbacks);
     auto ctx = state_helper.get_context();
 
-    fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+    GIVEN("Good case - DC") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
 
-    message_20::SupportedAppProtocolRequest req;
-    auto& ap = req.app_protocol.emplace_back();
-    ap.priority = 0;
-    ap.protocol_namespace = "Foobar";
-    ap.schema_id = 12;
-    ap.version_number_major = 2;
-    ap.version_number_minor = 11;
+        message_20::SupportedAppProtocolRequest req;
+        auto& ap = req.app_protocol.emplace_back();
+        ap.priority = 1;
+        ap.protocol_namespace = "urn:iso:std:iso:15118:-20:DC";
+        ap.schema_id = 1;
+        ap.version_number_major = 1;
+        ap.version_number_minor = 0;
 
-    state_helper.handle_request(req);
-    const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
 
-    REQUIRE(result.transitioned() == false);
-    REQUIRE(fsm.get_current_state_id() == d20::StateID::SupportedAppProtocol);
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SessionSetup);
 
-    const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
-    REQUIRE(response_message.has_value());
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
 
-    const auto& supported_app_res = response_message.value();
+            const auto& supported_app_res = response_message.value();
 
-    REQUIRE(supported_app_res.response_code ==
-            message_20::SupportedAppProtocolResponse::ResponseCode::Failed_NoNegotiation);
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
+            REQUIRE(supported_app_res.schema_id.value_or(0) == 1);
+        }
+    }
+
+    GIVEN("Good case - Custom") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+
+        message_20::SupportedAppProtocolRequest req;
+
+        auto& ap = req.app_protocol.emplace_back();
+        ap.priority = 1;
+        ap.protocol_namespace = "urn:iso:std:iso:15118:-20:AABB";
+        ap.schema_id = 1;
+        ap.version_number_major = 1;
+        ap.version_number_minor = 0;
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SessionSetup);
+
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& supported_app_res = response_message.value();
+
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
+            REQUIRE(supported_app_res.schema_id.value_or(0) == 1);
+        }
+    }
+
+    GIVEN("Good case - Priority") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+
+        message_20::SupportedAppProtocolRequest req;
+        auto& ap_dc = req.app_protocol.emplace_back();
+        ap_dc.priority = 2;
+        ap_dc.protocol_namespace = "urn:iso:std:iso:15118:-20:DC";
+        ap_dc.schema_id = 1;
+        ap_dc.version_number_major = 1;
+        ap_dc.version_number_minor = 0;
+
+        auto& ap_custom = req.app_protocol.emplace_back();
+        ap_custom.priority = 1;
+        ap_custom.protocol_namespace = "urn:iso:std:iso:15118:-20:AABB";
+        ap_custom.schema_id = 3;
+        ap_custom.version_number_major = 1;
+        ap_custom.version_number_minor = 0;
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SessionSetup);
+
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& supported_app_res = response_message.value();
+
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
+            REQUIRE(supported_app_res.schema_id.value_or(0) == 3);
+        }
+    }
+
+    GIVEN("Bad case - Unknown protocol namespace") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+
+        message_20::SupportedAppProtocolRequest req;
+        auto& ap = req.app_protocol.emplace_back();
+        ap.priority = 1;
+        ap.protocol_namespace = "Foobar";
+        ap.schema_id = 12;
+        ap.version_number_major = 2;
+        ap.version_number_minor = 11;
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SupportedAppProtocol);
+
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& supported_app_res = response_message.value();
+
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::Failed_NoNegotiation);
+        }
+    }
+
+    GIVEN("Bad case - empty app protocol") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+
+        message_20::SupportedAppProtocolRequest req;
+        req.app_protocol.emplace_back();
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SupportedAppProtocol);
+
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& supported_app_res = response_message.value();
+
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::Failed_NoNegotiation);
+        }
+    }
 }


### PR DESCRIPTION
## Describe your changes
- Add an option to select custom protocol namespaces for the SupportedAppProtocolRes message
- Refactoring supported app protocol handling

## Issue ticket number and link
Right now custom protocol namespace can not be selected

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

