### PR TITLE
tests: Fix cmake to change into pki subdirectory before copying configs

### DIFF
--- a/test/iso15118/io/CMakeLists.txt
+++ b/test/iso15118/io/CMakeLists.txt
@@ -14,8 +14,7 @@ add_executable(connection_openssl_test)
 add_custom_command(
     TARGET connection_openssl_test POST_BUILD
     COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/pki
-    COMMAND cd pki && cp pki.sh ${CMAKE_CURRENT_BINARY_DIR}/pki
-    COMMAND cp -r configs ${CMAKE_CURRENT_BINARY_DIR}/pki
+    COMMAND cd pki && cp pki.sh ${CMAKE_CURRENT_BINARY_DIR}/pki && cp -r configs ${CMAKE_CURRENT_BINARY_DIR}/pki
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_sources(connection_openssl_test


### PR DESCRIPTION
Otherwise this fails with a file not found error

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

